### PR TITLE
Set the tree version to 0.2.39-SNAPSHOT

### DIFF
--- a/mcp/bom/pom.xml
+++ b/mcp/bom/pom.xml
@@ -56,7 +56,7 @@
               <artifact>
                 <groupId>ru.aiedt.mcp</groupId>
                 <artifactId>default</artifactId>
-                <version>0.2.38-SNAPSHOT</version>
+                <version>0.2.39-SNAPSHOT</version>
               </artifact>
             </target>
             <dependency-resolution>

--- a/mcp/bundles/pom.xml
+++ b/mcp/bundles/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/bundles/ru.aiedt.mcp.server/META-INF/MANIFEST.MF
+++ b/mcp/bundles/ru.aiedt.mcp.server/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
-Bundle-Version: 0.2.38.qualifier
+Bundle-Version: 0.2.39.qualifier
 Bundle-SymbolicName: ru.aiedt.mcp.server;singleton:=true
 Bundle-Activator: ru.aiedt.mcp.server.Activator
 Bundle-ActivationPolicy: lazy

--- a/mcp/bundles/ru.aiedt.mcp.server/pom.xml
+++ b/mcp/bundles/ru.aiedt.mcp.server/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/features/pom.xml
+++ b/mcp/features/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/features/ru.aiedt.mcp.server.feature/feature.xml
+++ b/mcp/features/ru.aiedt.mcp.server.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
     id="ru.aiedt.mcp.server.feature"
     label="%featureName"
-    version="0.2.38.qualifier"
+    version="0.2.39.qualifier"
     provider-name="%providerName">
 
     <description>

--- a/mcp/features/ru.aiedt.mcp.server.feature/pom.xml
+++ b/mcp/features/ru.aiedt.mcp.server.feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>features</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/pom.xml
+++ b/mcp/pom.xml
@@ -33,5 +33,5 @@
     <module>repositories</module>
   </modules>
 
-<version>0.2.38-SNAPSHOT</version>
+<version>0.2.39-SNAPSHOT</version>
 </project>

--- a/mcp/repositories/pom.xml
+++ b/mcp/repositories/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/repositories/ru.aiedt.mcp.server.repository/pom.xml
+++ b/mcp/repositories/ru.aiedt.mcp.server.repository/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>repositories</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/targets/default/pom.xml
+++ b/mcp/targets/default/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>targets</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/targets/pom.xml
+++ b/mcp/targets/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/tests/pom.xml
+++ b/mcp/tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>parent</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mcp/tests/ru.aiedt.mcp.server.tests/META-INF/MANIFEST.MF
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AI-EDT Tests
 Bundle-SymbolicName: ru.aiedt.mcp.server.tests
-Bundle-Version: 0.2.38.qualifier
+Bundle-Version: 0.2.39.qualifier
 Bundle-Vendor: AI-EDT
 Fragment-Host: ru.aiedt.mcp.server;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/mcp/tests/ru.aiedt.mcp.server.tests/pom.xml
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ru.aiedt.mcp</groupId>
     <artifactId>tests</artifactId>
-    <version>0.2.38-SNAPSHOT</version>
+    <version>0.2.39-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Newest tag is v0.2.38, so the tree carries one micro above it.

A tree left at the released version makes a local build sort above the release: an empty qualifier ranks below a timestamped one, so `0.2.38.<timestamp>` wins over `0.2.38` in the p2 profile.

`Fragment-Host` in the test fragment stays at `0.1.0`. It is an attachment floor rather than the fragment's own version; `Bundle-Version` is what moves.

Build: 1993 tests, no failures. All eight gates pass.
