### PR TITLE
Refuse a removal that removes nothing

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -508,7 +508,7 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-2006 test methods across 209 test classes; 113 classes have a test of their own, median 9 methods each.
+2008 test methods across 209 test classes; 113 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 379 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 113 | a test class named after it |
-| exercised | 63 | reached by some other test |
+| exercised | 64 | reached by some other test |
 | tool-sweep | 90 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 62 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **378** | across 207 test classes |
+| **total** | **379** | across 209 test classes |
 
 ## untested (0)
 
@@ -267,7 +267,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (63)
+## exercised (64)
 
 **(root)**
 - Activator
@@ -305,6 +305,7 @@ _none_
 - BmRightsHelper
 - BmSupportRegistryHelper
 - BmTemplateHelper
+- ContainerScope
 - ErrorTags
 - JUnitRunOutcome
 - OffScreenTextViewer
@@ -507,9 +508,9 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-1993 test methods across 207 test classes; 113 classes have a test of their own, median 9 methods each.
+2006 test methods across 209 test classes; 113 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 378 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 379 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ContainerScope.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ContainerScope.java
@@ -1,0 +1,116 @@
+/**
+ * AI-EDT - 1C AI tools for EDT
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+/**
+ * What kind of container an FQN names, decided by the shape of the path.
+ * <p>
+ * The universal item operations have to send the caller to the operation that can actually do the
+ * work, and to do that they first have to know what they are looking at. Two of them worked this
+ * out by searching the FQN for a substring, and they disagreed with each other: one treated
+ * {@code CommonForm.X} as a form, the other did not, so the same container answered differently
+ * depending on which operation was asked.
+ * </p>
+ * <p>
+ * A substring is also wrong on its own terms. {@code Catalog.TemplateSettings} contains
+ * {@code .Template} and was read as a composition schema, so a caller removing an attribute of that
+ * catalogue was sent to the schema workshop. The name of an object is not a statement about its
+ * kind.
+ * </p>
+ * <p>
+ * Kinds sit at the even indices of a metadata FQN - {@code Type.Name.Kind.Name.Kind.Name} - so this
+ * reads them by position. A catalogue whose NAME is "TemplateSettings" carries nothing at an index
+ * where a kind would be, and a form whose name happens to be "Template" is still a form.
+ * </p>
+ */
+public enum ContainerScope
+{
+    /** A managed form, either owned by an object or a common one. */
+    FORM,
+
+    /** A template - a spreadsheet document or a composition schema; the FQN does not say which. */
+    TEMPLATE,
+
+    /** Anything else: the metadata object itself, and its attributes and tabular sections. */
+    METADATA_OBJECT;
+
+    /** Root types that decide the answer on their own, without a kind segment. */
+    private static final String COMMON_FORM = "CommonForm"; //$NON-NLS-1$
+
+    private static final String COMMON_TEMPLATE = "CommonTemplate"; //$NON-NLS-1$
+
+    /**
+     * What the FQN names.
+     *
+     * @param containerFqn the container's FQN; may be <code>null</code>
+     * @return the scope, {@link #METADATA_OBJECT} when nothing says otherwise - including for an
+     *         absent or unparsable FQN, because a guess of "form" would send the caller to an
+     *         operation that cannot resolve it
+     */
+    public static ContainerScope of(String containerFqn)
+    {
+        if (containerFqn == null || containerFqn.isEmpty())
+        {
+            return METADATA_OBJECT;
+        }
+        String[] segments = MetadataTypeCatalog.normalizeFqn(containerFqn).split("\\."); //$NON-NLS-1$
+        if (segments.length == 0)
+        {
+            return METADATA_OBJECT;
+        }
+        if (COMMON_FORM.equals(segments[0]))
+        {
+            return FORM;
+        }
+        if (COMMON_TEMPLATE.equals(segments[0]))
+        {
+            return TEMPLATE;
+        }
+        for (int i = 2; i < segments.length; i += 2)
+        {
+            if (isFormKind(segments[i]))
+            {
+                return FORM;
+            }
+            if (isTemplateKind(segments[i]))
+            {
+                return TEMPLATE;
+            }
+        }
+        return METADATA_OBJECT;
+    }
+
+    /**
+     * Whether the segment names the form kind.
+     * <p>
+     * The plural is accepted because a caller that built the FQN from a source path writes
+     * {@code Forms} - the directory is named that way - and refusing it would reject a container
+     * that exists.
+     * </p>
+     *
+     * @param segment one segment of the FQN
+     * @return <code>true</code> when it names a form
+     */
+    private static boolean isFormKind(String segment)
+    {
+        return "Form".equals(segment) //$NON-NLS-1$
+            || "Forms".equals(segment) //$NON-NLS-1$
+            || "Форма".equals(segment); //$NON-NLS-1$
+    }
+
+    /**
+     * Whether the segment names the template kind.
+     *
+     * @param segment one segment of the FQN
+     * @return <code>true</code> when it names a template
+     */
+    private static boolean isTemplateKind(String segment)
+    {
+        return "Template".equals(segment) //$NON-NLS-1$
+            || "Templates".equals(segment) //$NON-NLS-1$
+            || "Макет".equals(segment); //$NON-NLS-1$
+    }
+}

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ContainerScope.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ContainerScope.java
@@ -25,6 +25,13 @@ package ru.aiedt.mcp.server.support;
  * reads them by position. A catalogue whose NAME is "TemplateSettings" carries nothing at an index
  * where a kind would be, and a form whose name happens to be "Template" is still a form.
  * </p>
+ * <p>
+ * <b>Kind segments are matched in English only, deliberately.</b> The root type is normalized on the
+ * way in, so a Russian ROOT resolves; a Russian KIND is normalized nowhere, so accepting one here
+ * would classify a container that the operations downstream then fail to resolve - a call answered
+ * "this is a form" and then "no such form". Reading a spelling this project cannot yet act on is a
+ * promise it cannot keep.
+ * </p>
  */
 public enum ContainerScope
 {
@@ -97,8 +104,7 @@ public enum ContainerScope
     private static boolean isFormKind(String segment)
     {
         return "Form".equals(segment) //$NON-NLS-1$
-            || "Forms".equals(segment) //$NON-NLS-1$
-            || "Форма".equals(segment); //$NON-NLS-1$
+            || "Forms".equals(segment); //$NON-NLS-1$
     }
 
     /**
@@ -110,7 +116,6 @@ public enum ContainerScope
     private static boolean isTemplateKind(String segment)
     {
         return "Template".equals(segment) //$NON-NLS-1$
-            || "Templates".equals(segment) //$NON-NLS-1$
-            || "Макет".equals(segment); //$NON-NLS-1$
+            || "Templates".equals(segment); //$NON-NLS-1$
     }
 }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
@@ -17,6 +17,7 @@ import ru.aiedt.mcp.server.wire.ToolResult;
 import ru.aiedt.mcp.server.support.BmDcsHelper;
 import ru.aiedt.mcp.server.support.BmExtensionHelper;
 import ru.aiedt.mcp.server.support.BmFormHelper;
+import ru.aiedt.mcp.server.support.ContainerScope;
 import ru.aiedt.mcp.server.support.ErrorTags;
 import ru.aiedt.mcp.server.support.MetadataTypeCatalog;
 import ru.aiedt.mcp.server.support.ProjectResolver;
@@ -227,13 +228,16 @@ final class MiscOps
             return ToolResult.error("move_item requires name plus formFqn (or containerFqn) " //$NON-NLS-1$
                 + "naming the form that holds it.").toJson(); //$NON-NLS-1$
         }
-        if (target.contains(".Template") || target.contains(".DCS")) //$NON-NLS-1$ //$NON-NLS-2$
+        // One parse of the path decides this, shared with remove_item. The two used to read the FQN
+        // separately - one accepted a common form, the other did not - so the same container got
+        // two answers depending on which operation was asked.
+        ContainerScope scope = ContainerScope.of(target);
+        if (scope == ContainerScope.TEMPLATE)
         {
             return ToolResult.error("move_item works inside a form. For a composition schema " //$NON-NLS-1$
                 + "use dcs_workshop (moveSchemaParameter / moveSettingsItem).").toJson(); //$NON-NLS-1$
         }
-        if (!target.contains(".Forms.") && !target.contains(".Form.") //$NON-NLS-1$ //$NON-NLS-2$
-            && !target.startsWith("CommonForm.")) //$NON-NLS-1$
+        if (scope != ContainerScope.FORM)
         {
             return ToolResult.error("move_item works inside a form, and '" + target //$NON-NLS-1$
                 + "' is not one. To reorder the content of a metadata object use the " //$NON-NLS-1$
@@ -280,10 +284,23 @@ final class MiscOps
     }
 
     /**
-     * 1.40: universal {@code removeItem} - routes by container FQN shape
-     * the same way {@link #opMoveItem(Map)} does. For metadata-objects
-     * (Catalog/Document/etc.) it forwards to {@code removeObjectAttribute}
-     * or {@code removeTabularSection} based on container shape.
+     * The universal {@code remove_item}, which removes nothing and says so.
+     * <p>
+     * Every context it can be pointed at - a form, a template, a metadata object - has its own
+     * removal operation, and this one forwards to none of them. That is a decision, not a gap: the
+     * typed operations resolve their own containers and report their own failures, and a router
+     * that mutated on their behalf would have to duplicate both.
+     * </p>
+     * <p>
+     * <b>What was wrong is the answer, not the routing.</b> All three branches came back
+     * {@code success: true} carrying a sentence that named another operation. A caller reading the
+     * success flag - which is what a caller reads - took the item for removed. Measured on a stand
+     * 31.08: the element stayed on the form and the marker EDT had raised on it stayed with it,
+     * through two identical calls.
+     * </p>
+     *
+     * @param params the call's arguments.
+     * @return a refusal naming the operation that does the work, in every context
      */
     String opRemoveItem(Map<String, String> params)
     {
@@ -293,35 +310,57 @@ final class MiscOps
         {
             return ToolResult.error("removeItem requires containerFqn and name parameters.").toJson(); //$NON-NLS-1$
         }
-        // Form scope - advisory router: form / DCS / typed-metadata contexts have
-        // dedicated remove operations, so surface the right one instead of mutating
-        // here (the previous formParams map was built and never forwarded - dead code).
-        if (containerFqn.contains(".Forms.") || containerFqn.contains(".Form."))
-        {
-            return ToolResult.success()
-                .put("message", "removeItem routed to form context - call edit_form operation=removeItem with formFqn="
-                    + containerFqn + " name=" + itemName)
-                .put("removeItemRouting", java.util.Collections.singletonMap("scope", "form"))
-                .toJson();
-        }
-        // DCS scope
-        if (containerFqn.contains(".Template") || containerFqn.contains(".DCS"))
-        {
-            return ToolResult.success()
-                .put("message", "removeItem routed to DCS context - call dcs_workshop operation=remove_item")
-                .put("removeItemRouting", java.util.Collections.singletonMap("scope", "dcs"))
-                .toJson();
-        }
-        // Metadata-object scope - try to route to attribute or TS removal
-        // by checking whether the parent owner has a TS with this name first.
-        Map<String, Object> data = new LinkedHashMap<>();
-        data.put("containerFqn", containerFqn);
-        data.put("itemName", itemName);
-        data.put("hint", "For attributes use removeObjectAttribute, for tabular sections use removeTabularSection.");
-        return ToolResult.success()
-            .put("message", "removeItem in metadata-object context - use the typed remove operation")
-            .put("removeItemRouting", data)
+        ContainerScope scope = ContainerScope.of(containerFqn);
+        Map<String, Object> routing = new LinkedHashMap<>();
+        routing.put("containerFqn", containerFqn); //$NON-NLS-1$
+        routing.put("itemName", itemName); //$NON-NLS-1$
+        routing.put("scope", scope.name().toLowerCase(java.util.Locale.ROOT)); //$NON-NLS-1$
+        return ToolResult.error(removalRefusal(scope, containerFqn, itemName))
+            .put("removeItemRouting", routing) //$NON-NLS-1$
             .toJson();
+    }
+
+    /**
+     * The sentence that says nothing was removed and names what removes it.
+     * <p>
+     * Two of the three name more than one operation, and that is not vagueness. A template's
+     * contents are reached through a different workshop depending on what the template holds, and
+     * for a metadata object the name alone does not say whether it is an attribute or a tabular
+     * section - the two have separate operations. Naming one of them would be a guess presented as
+     * an instruction.
+     * </p>
+     *
+     * @param scope what the container FQN names.
+     * @param containerFqn the container, repeated into the sentence so the caller can see what was
+     *            read.
+     * @param itemName the item the caller wanted gone.
+     * @return the refusal text
+     */
+    private static String removalRefusal(ContainerScope scope, String containerFqn, String itemName)
+    {
+        StringBuilder said = new StringBuilder("Nothing was removed. "); //$NON-NLS-1$
+        switch (scope)
+        {
+            case FORM:
+                said.append("'").append(containerFqn).append("' names a form, and remove_item does ") //$NON-NLS-1$ //$NON-NLS-2$
+                    .append("not touch one. Call edit_form operation=remove_item with formFqn=") //$NON-NLS-1$
+                    .append(containerFqn).append(" name=").append(itemName).append('.'); //$NON-NLS-1$
+                break;
+            case TEMPLATE:
+                said.append("'").append(containerFqn).append("' names a template. Which operation ") //$NON-NLS-1$ //$NON-NLS-2$
+                    .append("removes from it depends on what the template holds: dcs_workshop for ") //$NON-NLS-1$
+                    .append("a composition schema (remove_dataset, remove_parameter, ") //$NON-NLS-1$
+                    .append("remove_settings_item and the rest, one per kind of item), ") //$NON-NLS-1$
+                    .append("mxl_workshop operation=remove_named_area for a spreadsheet document."); //$NON-NLS-1$
+                break;
+            default:
+                said.append("'").append(containerFqn).append("' names a metadata object, and the ") //$NON-NLS-1$ //$NON-NLS-2$
+                    .append("operation depends on what '").append(itemName).append("' is: ") //$NON-NLS-1$ //$NON-NLS-2$
+                    .append("remove_object_attribute for an attribute, remove_tabular_section for ") //$NON-NLS-1$
+                    .append("a tabular section. The name on its own does not say which."); //$NON-NLS-1$
+                break;
+        }
+        return said.toString();
     }
     // -----------------------------------------------------------------------
     // 1.40: Extensions group (5 ops via BmExtensionHelper)

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
@@ -222,12 +222,16 @@ final class MiscOps
         String formFqn = JsonUtils.extractStringArgument(params, "formFqn"); //$NON-NLS-1$
         String itemName = JsonUtils.extractStringArgument(params, "name"); //$NON-NLS-1$
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
-        final String target = formFqn != null && !formFqn.isEmpty() ? formFqn : containerFqn;
-        if (target == null || target.isEmpty() || itemName == null || itemName.isEmpty())
+        String named = formFqn != null && !formFqn.isEmpty() ? formFqn : containerFqn;
+        if (named == null || named.isEmpty() || itemName == null || itemName.isEmpty())
         {
             return ToolResult.error("move_item requires name plus formFqn (or containerFqn) " //$NON-NLS-1$
                 + "naming the form that holds it.").toJson(); //$NON-NLS-1$
         }
+        // Normalized once, and the SAME string is what gets resolved. Deciding the scope on a
+        // canonical FQN and then resolving the caller's spelling would accept a Russian root here
+        // and answer "no such form" a moment later.
+        final String target = MetadataTypeCatalog.normalizeFqn(named);
         // One parse of the path decides this, shared with remove_item. The two used to read the FQN
         // separately - one accepted a common form, the other did not - so the same container got
         // two answers depending on which operation was asked.

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AContainerIsJudgedByItsPathTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AContainerIsJudgedByItsPathTest.java
@@ -41,6 +41,29 @@ public class AContainerIsJudgedByItsPathTest
         assertEquals(ContainerScope.FORM, ContainerScope.of("CommonForm.ПодборТоваров.Form"));
     }
 
+    /**
+     * The root type is normalized on the way in, so the Russian spelling of a root answers the same
+     * as the English one - and the operation that resolves the container is handed the same
+     * canonical FQN, so it does not then fail to find what was just recognised.
+     */
+    @Test
+    public void aRussianRootIsTheSameContainer()
+    {
+        assertEquals(ContainerScope.FORM, ContainerScope.of("ОбщаяФорма.ПодборТоваров"));
+        assertEquals(ContainerScope.TEMPLATE, ContainerScope.of("ОбщийМакет.ПечатьЭтикетки"));
+    }
+
+    /**
+     * A Russian KIND segment is not recognised, and that is deliberate: nothing normalizes a kind,
+     * so calling it a form would be answered by "no such form" one step later.
+     */
+    @Test
+    public void aRussianKindIsNotRecognised()
+    {
+        assertEquals(ContainerScope.METADATA_OBJECT,
+            ContainerScope.of("Catalog.Товары.Форма.ФормаСписка"));
+    }
+
     @Test
     public void aTemplateIsATemplate()
     {

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AContainerIsJudgedByItsPathTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AContainerIsJudgedByItsPathTest.java
@@ -1,0 +1,95 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * What an FQN says about the kind of container it names.
+ * <p>
+ * The two universal item operations used to work this out by searching the text for a substring,
+ * and they disagreed: one counted {@code CommonForm.X} a form, the other did not. A substring is
+ * also wrong on its own terms - {@code Catalog.TemplateSettings} contains {@code .Template} and was
+ * read as a composition schema, so removing an attribute of that catalogue sent the caller to the
+ * schema workshop.
+ * </p>
+ */
+public class AContainerIsJudgedByItsPathTest
+{
+    @Test
+    public void aFormOfAnObjectIsAForm()
+    {
+        assertEquals(ContainerScope.FORM, ContainerScope.of("Catalog.Товары.Form.ФормаСписка"));
+        assertEquals(ContainerScope.FORM, ContainerScope.of("Catalog.Товары.Form.ФормаСписка.Form"));
+        assertEquals(ContainerScope.FORM, ContainerScope.of("Document.Заказ.Forms.ФормаДокумента"));
+    }
+
+    /**
+     * The spelling with the trailing kind and the one without both name the same common form, and
+     * the neighbouring operation accepted only one of them.
+     */
+    @Test
+    public void aCommonFormIsAFormInBothSpellings()
+    {
+        assertEquals(ContainerScope.FORM, ContainerScope.of("CommonForm.ПодборТоваров"));
+        assertEquals(ContainerScope.FORM, ContainerScope.of("CommonForm.ПодборТоваров.Form"));
+    }
+
+    @Test
+    public void aTemplateIsATemplate()
+    {
+        assertEquals(ContainerScope.TEMPLATE, ContainerScope.of("Catalog.Товары.Template.Печать"));
+        assertEquals(ContainerScope.TEMPLATE, ContainerScope.of("CommonTemplate.ПечатьЭтикетки"));
+    }
+
+    /**
+     * The name of an object is not a statement about its kind. Both of these are ordinary
+     * catalogues, and the substring search called the first one a composition schema.
+     */
+    @Test
+    public void anObjectNamedAfterAKindIsStillAnObject()
+    {
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of("Catalog.TemplateSettings"));
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of("Catalog.НастройкиTemplate"));
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of("Catalog.FormDesigner"));
+    }
+
+    /**
+     * A kind segment sits at an even index. A name at an odd one carries no claim about the kind,
+     * however much it reads like one.
+     */
+    @Test
+    public void aNameThatReadsLikeAKindDecidesNothing()
+    {
+        assertEquals(ContainerScope.FORM, ContainerScope.of("Catalog.Товары.Form.Template"));
+        assertEquals(ContainerScope.TEMPLATE, ContainerScope.of("Catalog.Товары.Template.Form"));
+    }
+
+    @Test
+    public void anAttributeOfAnObjectIsAnObject()
+    {
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of("Catalog.Товары"));
+        assertEquals(ContainerScope.METADATA_OBJECT,
+            ContainerScope.of("Catalog.Товары.Attribute.Цена"));
+        assertEquals(ContainerScope.METADATA_OBJECT,
+            ContainerScope.of("Document.Заказ.TabularSection.Строки"));
+    }
+
+    /**
+     * Nothing to read is not a reason to guess "form": the form operations would then be handed a
+     * container they cannot resolve, and the refusal would name the wrong one.
+     */
+    @Test
+    public void whatCannotBeReadIsNotAForm()
+    {
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of(null));
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of(""));
+        assertEquals(ContainerScope.METADATA_OBJECT, ContainerScope.of("Товары"));
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ARemovalThatRemovedNothingSaysSoTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ARemovalThatRemovedNothingSaysSoTest.java
@@ -1,0 +1,127 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * What {@code remove_item} answers, given that it removes nothing anywhere.
+ * <p>
+ * All three of its branches used to come back {@code success: true} carrying a sentence that named
+ * another operation. A caller reads the success flag, so the item was taken for removed; measured
+ * on a stand 31.08, the element stayed on the form and the marker EDT had raised on it stayed with
+ * it, through two identical calls.
+ * </p>
+ * <p>
+ * The branch count matters as much as the branch: three contexts answered this way, and only one of
+ * them was measured.
+ * </p>
+ */
+public class ARemovalThatRemovedNothingSaysSoTest
+{
+    private static JsonObject removeFrom(String containerFqn)
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("containerFqn", containerFqn);
+        params.put("name", "Строки");
+        params.put("projectName", "AnyProject");
+        return JsonParser.parseString(new MiscOps().opRemoveItem(params)).getAsJsonObject();
+    }
+
+    private static void isRefusal(JsonObject answered)
+    {
+        assertFalse("remove_item removed nothing and must not answer success",
+            answered.has("success") && answered.get("success").getAsBoolean());
+        assertTrue("the refusal has to say that nothing was removed",
+            answered.toString().contains("Nothing was removed"));
+    }
+
+    @Test
+    public void aFormIsRefusedAndTheFormOperationIsNamed()
+    {
+        JsonObject answered = removeFrom("Catalog.Товары.Form.ФормаСписка.Form");
+        isRefusal(answered);
+        assertTrue("the caller needs the operation that does remove from a form",
+            answered.toString().contains("edit_form operation=remove_item"));
+    }
+
+    /** The spelling the neighbouring operation accepted and this one did not. */
+    @Test
+    public void aCommonFormIsRefusedAsAForm()
+    {
+        JsonObject answered = removeFrom("CommonForm.ПодборТоваров");
+        isRefusal(answered);
+        assertTrue("a common form is a form, whichever way its FQN is written",
+            answered.toString().contains("edit_form operation=remove_item"));
+    }
+
+    /**
+     * A template is reached through a different workshop depending on what it holds, so naming one
+     * of them would be a guess presented as an instruction.
+     */
+    @Test
+    public void aTemplateIsRefusedAndBothWorkshopsAreNamed()
+    {
+        JsonObject answered = removeFrom("Catalog.Товары.Template.Печать");
+        isRefusal(answered);
+        String said = answered.toString();
+        assertTrue("a composition schema is reached through its own workshop",
+            said.contains("dcs_workshop"));
+        assertTrue("a spreadsheet document is reached through another",
+            said.contains("mxl_workshop"));
+    }
+
+    /**
+     * The name alone does not say whether it is an attribute or a tabular section, and the two have
+     * separate operations. Both are named, with what tells them apart.
+     */
+    @Test
+    public void aMetadataObjectIsRefusedAndBothOperationsAreNamed()
+    {
+        JsonObject answered = removeFrom("Catalog.Товары");
+        isRefusal(answered);
+        String said = answered.toString();
+        assertTrue(said.contains("remove_object_attribute"));
+        assertTrue(said.contains("remove_tabular_section"));
+    }
+
+    /**
+     * A catalogue whose name contains a kind word is a catalogue. The substring search read this
+     * one as a composition schema and named the wrong workshop.
+     */
+    @Test
+    public void anObjectNamedAfterAKindGetsTheObjectAnswer()
+    {
+        JsonObject answered = removeFrom("Catalog.TemplateSettings");
+        isRefusal(answered);
+        String said = answered.toString();
+        assertTrue("this is a catalogue, not a template",
+            said.contains("remove_object_attribute"));
+        assertFalse("naming a workshop here sends the caller nowhere",
+            said.contains("dcs_workshop"));
+    }
+
+    /** A missing argument was already a refusal, and stays one. */
+    @Test
+    public void aCallWithoutAContainerIsStillRefused()
+    {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "Строки");
+        JsonObject answered =
+            JsonParser.parseString(new MiscOps().opRemoveItem(params)).getAsJsonObject();
+        assertFalse(answered.has("success") && answered.get("success").getAsBoolean());
+    }
+}


### PR DESCRIPTION
`remove_item` answered `success: true` in every context it can be pointed at - a form, a template, a metadata object - carrying a sentence that named another operation. The item stayed where it was. Measured on a stand 31.08: the element stayed on the form and the marker EDT had raised on it stayed with it, through two identical calls.

All three branches now refuse and name what does the work. Two of them name more than one operation, because one name would be a guess: which workshop reaches into a template depends on what the template holds, and for a metadata object the name alone does not say whether it is an attribute or a tabular section.

The template branch named `dcs_workshop operation=remove_item`, which does not exist. A composition schema removes by kind of item - `remove_dataset`, `remove_parameter`, `remove_settings_item` and the rest.

Container kind now comes from the shape of the path, in `ContainerScope`, shared with `move_item`. The two read the FQN separately and disagreed: `CommonForm.X` was a form to one and not to the other. A substring search also read `Catalog.TemplateSettings` as a composition schema, so removing an attribute of that catalogue named the schema workshop.

`move_item` resolves the same normalized FQN it decided the scope on, so a Russian root reaches the form it names instead of failing a step later.

Build: 2008 tests, no failures. All eight gates pass.

Not yet verified on a running stand - the live check is outstanding.
