### PR TITLE
Take a set of properties when creating an object

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -507,7 +507,7 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-2008 test methods across 210 test classes; 113 classes have a test of their own, median 9 methods each.
+2016 test methods across 210 test classes; 113 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 378 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 62 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **378** | across 207 test classes |
+| **total** | **378** | across 210 test classes |
 
 ## untested (0)
 
@@ -507,7 +507,7 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-1993 test methods across 207 test classes; 113 classes have a test of their own, median 9 methods each.
+2008 test methods across 210 test classes; 113 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 378 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/tools/operation-parameters.md
+++ b/docs/tools/operation-parameters.md
@@ -82,7 +82,7 @@
 | `EditMetadataTool` | `clear_object_reference` | `dryRun`, `ownerFqn`, `projectName`, `property`, `valueFqn` | handler ObjectOps.opSetObjectReference |
 | `EditMetadataTool` | `create_form` | `dryRun`, `formName`, `formType`, `layout`, `name`, `ownerFqn`, `projectName`, `purpose`, `setAsDefault` | handler FormCreateOps.opCreateForm |
 | `EditMetadataTool` | `create_http_service` | `aliases`, `createModule`, `dryRun`, `handler`, `httpMethod`, `methodName`, `name`, `projectName`, `reuseSessions`, `rootURL`, `sessionMaxAge`, `urlTemplate`, `urlTemplateName`, `withHandlerStub` | handler ServiceOps.opCreateHttpService |
-| `EditMetadataTool` | `create_object` | `clientOrdinaryApplication`, `dryRun`, `externalConnection`, `global`, `name`, `objectType`, `privileged`, `projectName`, `server`, `serverCall`, `synonym` | handler ObjectOps.opCreateObject |
+| `EditMetadataTool` | `create_object` | `clientOrdinaryApplication`, `dryRun`, `externalConnection`, `global`, `name`, `objectType`, `privileged`, `projectName`, `properties`, `server`, `serverCall`, `synonym` | handler ObjectOps.opCreateObject |
 | `EditMetadataTool` | `create_object_command` | `commandParameterType`, `dryRun`, `name`, `ownerFqn`, `picture`, `projectName`, `title`, `tooltip` | handler SpecializedOps.opCreateObjectCommand |
 | `EditMetadataTool` | `create_route_map` | `bpFqn`, `dryRun`, `overwrite`, `ownerFqn`, `points`, `projectName`, `transitions` | handler RouteMapOps.opCreateRouteMap |
 | `EditMetadataTool` | `create_web_service` | `createModule`, `dryRun`, `handler`, `name`, `namespace`, `operationName`, `projectName`, `transactional`, `withHandlerStub` | handler ServiceOps.opCreateWebService |
@@ -217,12 +217,15 @@
 | `LaunchDebuggerTool` | `terminate_launch` | `all`, `applicationId` | delegate LaunchTerminator |
 | `LaunchDebuggerTool` | `wait_for_break` | `applicationId`, `timeoutMs`, `timeoutSeconds` | delegate SuspendWaiter |
 | `MxlWorkshopTool` | `add_drawing` | `beginColumn`, `beginColumnOffset`, `beginRow`, `beginRowOffset`, `drawingType`, `dryRun`, `endColumn`, `endColumnOffset`, `endRow`, `endRowOffset`, `formatIndex`, `language`, `ownerFqn`, `projectName`, `templateName`, `text`, `zOrder` | read in place |
+| `MxlWorkshopTool` | `add_named_area` | `areaKind`, `areaName`, `dryRun`, `fromCol`, `fromRow`, `ownerFqn`, `projectName`, `templateName`, `toCol`, `toRow` | read in place |
 | `MxlWorkshopTool` | `create_template` | `dryRun`, `ownerFqn`, `projectName`, `templateName`, `templateType` | read in place |
 | `MxlWorkshopTool` | `draw` | `dryRun`, `layout`, `ownerFqn`, `projectName`, `templateName` | read in place |
 | `MxlWorkshopTool` | `format_cells` | `autoColumnWidth`, `col`, `dryRun`, `fromCol`, `fromRow`, `ownerFqn`, `projectName`, `row`, `templateName`, `textPlacement`, `toCol`, `toRow` | read in place |
+| `MxlWorkshopTool` | `list_named_areas` | `ownerFqn`, `projectName`, `templateName` | read in place |
 | `MxlWorkshopTool` | `merge_cells` | `dryRun`, `fromCol`, `fromRow`, `ownerFqn`, `projectName`, `templateName`, `toCol`, `toRow` | read in place |
 | `MxlWorkshopTool` | `read_template` | `language`, `ownerFqn`, `projectName`, `templateName` | read in place |
 | `MxlWorkshopTool` | `remove_drawing` | `drawingId`, `dryRun`, `ownerFqn`, `projectName`, `templateName` | read in place |
+| `MxlWorkshopTool` | `remove_named_area` | `areaName`, `dryRun`, `ownerFqn`, `projectName`, `templateName` | read in place |
 | `MxlWorkshopTool` | `set_cell` | `col`, `dryRun`, `language`, `ownerFqn`, `projectName`, `row`, `templateName`, `text` | read in place |
 | `ProjectAdminFacadeTool` | `create_project` | `projectName`, `version` | delegate ProjectCreator |
 | `ProjectAdminFacadeTool` | `delete_project` | `deleteContent`, `projectName` | delegate ProjectRemover |

--- a/mcp/bundles/ru.aiedt.mcp.server/schema/operation-parameters.tsv
+++ b/mcp/bundles/ru.aiedt.mcp.server/schema/operation-parameters.tsv
@@ -75,7 +75,7 @@ EditMetadataTool	add_web_service_operation	dryRun,handler,name,ownerFqn,projectN
 EditMetadataTool	clear_object_reference	dryRun,ownerFqn,projectName,property,valueFqn	handler ObjectOps.opSetObjectReference
 EditMetadataTool	create_form	dryRun,formName,formType,layout,name,ownerFqn,projectName,purpose,setAsDefault	handler FormCreateOps.opCreateForm
 EditMetadataTool	create_http_service	aliases,createModule,dryRun,handler,httpMethod,methodName,name,projectName,reuseSessions,rootURL,sessionMaxAge,urlTemplate,urlTemplateName,withHandlerStub	handler ServiceOps.opCreateHttpService
-EditMetadataTool	create_object	clientOrdinaryApplication,dryRun,externalConnection,global,name,objectType,privileged,projectName,server,serverCall,synonym	handler ObjectOps.opCreateObject
+EditMetadataTool	create_object	clientOrdinaryApplication,dryRun,externalConnection,global,name,objectType,privileged,projectName,properties,server,serverCall,synonym	handler ObjectOps.opCreateObject
 EditMetadataTool	create_object_command	commandParameterType,dryRun,name,ownerFqn,picture,projectName,title,tooltip	handler SpecializedOps.opCreateObjectCommand
 EditMetadataTool	create_route_map	bpFqn,dryRun,overwrite,ownerFqn,points,projectName,transitions	handler RouteMapOps.opCreateRouteMap
 EditMetadataTool	create_web_service	createModule,dryRun,handler,name,namespace,operationName,projectName,transactional,withHandlerStub	handler ServiceOps.opCreateWebService
@@ -210,12 +210,15 @@ LaunchDebuggerTool	terminate	all,applicationId	delegate LaunchTerminator
 LaunchDebuggerTool	terminate_launch	all,applicationId	delegate LaunchTerminator
 LaunchDebuggerTool	wait_for_break	applicationId,timeoutMs,timeoutSeconds	delegate SuspendWaiter
 MxlWorkshopTool	add_drawing	beginColumn,beginColumnOffset,beginRow,beginRowOffset,drawingType,dryRun,endColumn,endColumnOffset,endRow,endRowOffset,formatIndex,language,ownerFqn,projectName,templateName,text,zOrder	read in place
+MxlWorkshopTool	add_named_area	areaKind,areaName,dryRun,fromCol,fromRow,ownerFqn,projectName,templateName,toCol,toRow	read in place
 MxlWorkshopTool	create_template	dryRun,ownerFqn,projectName,templateName,templateType	read in place
 MxlWorkshopTool	draw	dryRun,layout,ownerFqn,projectName,templateName	read in place
 MxlWorkshopTool	format_cells	autoColumnWidth,col,dryRun,fromCol,fromRow,ownerFqn,projectName,row,templateName,textPlacement,toCol,toRow	read in place
+MxlWorkshopTool	list_named_areas	ownerFqn,projectName,templateName	read in place
 MxlWorkshopTool	merge_cells	dryRun,fromCol,fromRow,ownerFqn,projectName,templateName,toCol,toRow	read in place
 MxlWorkshopTool	read_template	language,ownerFqn,projectName,templateName	read in place
 MxlWorkshopTool	remove_drawing	drawingId,dryRun,ownerFqn,projectName,templateName	read in place
+MxlWorkshopTool	remove_named_area	areaName,dryRun,ownerFqn,projectName,templateName	read in place
 MxlWorkshopTool	set_cell	col,dryRun,language,ownerFqn,projectName,row,templateName,text	read in place
 ProjectAdminFacadeTool	create_project	projectName,version	delegate ProjectCreator
 ProjectAdminFacadeTool	delete_project	deleteContent,projectName	delegate ProjectRemover

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmFormHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmFormHelper.java
@@ -2339,22 +2339,9 @@ public class BmFormHelper
      */
     private static boolean equalsModelDefault(Object target, String property)
     {
-        if (!(target instanceof org.eclipse.emf.ecore.EObject))
-        {
-            return false;
-        }
-        try
-        {
-            org.eclipse.emf.ecore.EObject eObject = (org.eclipse.emf.ecore.EObject)target;
-            org.eclipse.emf.ecore.EStructuralFeature feature =
-                eObject.eClass().getEStructuralFeature(property);
-            return feature != null && !eObject.eIsSet(feature);
-        }
-        catch (Exception notAnAnswer)
-        {
-            // A model that will not answer is not a model saying "default".
-            return false;
-        }
+        // One answer to this question, shared with the object path: create_object had the same
+        // problem and would otherwise have grown a second copy of it.
+        return BmObjectHelper.equalsModelDefault(target, property);
     }
 
     String setScalarProperty(Object item, String property, String value)

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmObjectHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmObjectHelper.java
@@ -83,6 +83,43 @@ public final class BmObjectHelper
      * @param paramType the type its setter takes, never <code>null</code>
      * @return the refusal text, never <code>null</code>
      */
+    /**
+     * Whether a written value is the one the model already had as its default.
+     * <p>
+     * A value equal to the default is not serialized, so the property reaches the object and the
+     * file shows nothing. Measured live 01.09: {@code create_object} on a scheduled job answered
+     * three properties applied and the .mdo carried two - {@code use=false} is the default and went
+     * unwritten. Read against the file, that looks like a property lost on the way.
+     * </p>
+     * <p>
+     * Asked of EMF rather than guessed: a feature that is not set after a write held that value
+     * already.
+     * </p>
+     *
+     * @param target the object written to.
+     * @param property the feature name.
+     * @return <code>true</code> when the value will not appear in the file
+     */
+    public static boolean equalsModelDefault(Object target, String property)
+    {
+        if (!(target instanceof EObject) || property == null)
+        {
+            return false;
+        }
+        try
+        {
+            EObject eObject = (EObject)target;
+            org.eclipse.emf.ecore.EStructuralFeature feature =
+                eObject.eClass().getEStructuralFeature(property);
+            return feature != null && !eObject.eIsSet(feature);
+        }
+        catch (RuntimeException notAnAnswer)
+        {
+            // A model that will not answer is not a model saying "default".
+            return false;
+        }
+    }
+
     static String compositeRefusal(String propertyName, Class<?> paramType)
     {
         String wanted = paramType.getSimpleName();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
@@ -321,6 +321,11 @@ public class EditMetadataTool implements IMcpTool
                 "Synonym for a newly created object or field. Auto-generated from the name when omitted, the " //$NON-NLS-1$
                 + "way the EDT wizard does it; a JSON object keyed by language code sets several languages at " //$NON-NLS-1$
                 + "once. Full text: operation=help topic=parameters.") //$NON-NLS-1$ //$NON-NLS-1$
+            .stringProperty("properties", //$NON-NLS-1$
+                "create_object: a JSON object of property name to value, applied to the new object before it " //$NON-NLS-1$
+                + "joins the configuration - e.g. {\"methodName\":\"CommonModule.A.B\",\"use\":false} on a " //$NON-NLS-1$
+                + "ScheduledJob. A property the object's type does not have is refused and NOTHING is created. " //$NON-NLS-1$
+                + "A property given both here and as its own argument must carry the same value.") //$NON-NLS-1$ //$NON-NLS-1$
             .booleanProperty("server", //$NON-NLS-1$
                 "create_object CommonModule: the Server context. Defaults to true when no context is given - " //$NON-NLS-1$
                 + "the common-module-type check requires one.") //$NON-NLS-1$ //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
@@ -321,7 +321,7 @@ public class EditMetadataTool implements IMcpTool
                 "Synonym for a newly created object or field. Auto-generated from the name when omitted, the " //$NON-NLS-1$
                 + "way the EDT wizard does it; a JSON object keyed by language code sets several languages at " //$NON-NLS-1$
                 + "once. Full text: operation=help topic=parameters.") //$NON-NLS-1$ //$NON-NLS-1$
-            .stringProperty("properties", //$NON-NLS-1$
+            .objectProperty("properties", //$NON-NLS-1$
                 "create_object: a JSON object of property name to value, applied to the new object before it " //$NON-NLS-1$
                 + "joins the configuration - e.g. {\"methodName\":\"CommonModule.A.B\",\"use\":false} on a " //$NON-NLS-1$
                 + "ScheduledJob. A property the object's type does not have is refused and NOTHING is created. " //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
@@ -172,6 +172,41 @@ final class ObjectOps
     }
 
     /**
+     * Says which folded flag carries a value the boolean reader will not recognise.
+     * <p>
+     * These six are read as arguments rather than applied as properties, so the generic setter -
+     * which would have refused an unusable value - never sees them. The boolean reader answers
+     * "not given" to anything outside true/false/1/0/yes/no, and "not given" is indistinguishable
+     * from a flag the caller left out.
+     * </p>
+     *
+     * @param declared the members of the properties object.
+     * @param isCommonModule whether the object being created reads these as arguments.
+     * @return the refusal text, or <code>null</code> when every folded flag is readable
+     */
+    static String unreadableFlag(Map<String, String> declared, boolean isCommonModule)
+    {
+        if (!isCommonModule)
+        {
+            return null;
+        }
+        for (Map.Entry<String, String> given : declared.entrySet())
+        {
+            if (!COMMON_MODULE_FLAGS.contains(given.getKey()))
+            {
+                continue;
+            }
+            if (JsonUtils.extractBooleanArgumentNullable(
+                Collections.singletonMap(given.getKey(), given.getValue()), given.getKey()) == null)
+            {
+                return "'" + given.getKey() + "' takes true or false, and '" + given.getValue() //$NON-NLS-1$ //$NON-NLS-2$
+                    + "' is neither. Nothing was created."; //$NON-NLS-1$
+            }
+        }
+        return null;
+    }
+
+    /**
      * Says which property was given twice with two different values.
      *
      * @param params the call's arguments.
@@ -278,6 +313,14 @@ final class ObjectOps
                 .toJson();
         }
 
+        // Asked before anything is read out of it. A properties object that cannot be used reads
+        // as no properties at all, and creating the object anyway would answer success for a
+        // request that was never carried out - the very thing this argument exists to stop.
+        String unusable = JsonUtils.objectArgumentProblem(params, "properties"); //$NON-NLS-1$
+        if (unusable != null)
+        {
+            return ToolResult.error(unusable + " Nothing was created.").toJson(); //$NON-NLS-1$
+        }
         // A property named twice - once as an argument, once in the properties object - with two
         // different values is a contradiction, and picking one of them silently would write
         // something the caller did not ask for. Equal values are not a contradiction.
@@ -296,6 +339,16 @@ final class ObjectOps
             effective.putIfAbsent(given.getKey(), given.getValue());
         }
 
+        // A flag folded in from the properties object goes through the boolean reader, and that
+        // reader answers "not given" to anything it does not recognise. Without this check
+        // {"server":"tru"} would read as an unnamed context, the default would be written, and the
+        // call would succeed as though the property had never been asked for.
+        String unreadable = unreadableFlag(declared, "CommonModule".equals(englishType)); //$NON-NLS-1$
+        if (unreadable != null)
+        {
+            return ToolResult.error(unreadable).toJson();
+        }
+
         // 3.8.2: extension CommonModule guards (privileged, global+server). The flags are
         // hoisted to finals so the BM task below can also APPLY them to the created module
         // - without that the module is created with no execution context and fails EDT's
@@ -304,8 +357,17 @@ final class ObjectOps
 
         final Map<String, String> remaining = propertiesToApply(declared, isCommonModule);
         // Named in the answer, because "success" on its own does not say which properties reached
-        // the object - and that is exactly what could not be told apart before.
+        // the object - and that is exactly what could not be told apart before. A flag folded into
+        // the arguments belongs here too: it was asked for in the properties object and it was
+        // written, and leaving it out would say the opposite of what happened.
         final List<String> applied = new ArrayList<>();
+        for (String property : declared.keySet())
+        {
+            if (!remaining.containsKey(property) && !SERVICE_ARGUMENTS.contains(property))
+            {
+                applied.add(property);
+            }
+        }
         final Boolean cmPrivileged = isCommonModule
             ? JsonUtils.extractBooleanArgumentNullable(effective, "privileged") : null; //$NON-NLS-1$
         final Boolean cmGlobal = isCommonModule

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
@@ -125,15 +125,110 @@ final class ObjectOps
             && !Boolean.TRUE.equals(serverCall);
     }
 
+    /**
+     * What steers the call rather than describing the object. None of these is a property of
+     * anything, so a properties object carrying one has nothing to apply.
+     */
+    private static final Set<String> SERVICE_ARGUMENTS =
+        Collections.unmodifiableSet(new java.util.HashSet<>(Arrays.asList(
+            "projectName", "objectType", "name", "synonym", "dryRun", "properties"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+
+    /**
+     * The execution contexts a common module takes as arguments of its own. Only that type reads
+     * them by name; on any other type a property of the same name is an ordinary property.
+     */
+    private static final Set<String> COMMON_MODULE_FLAGS =
+        Collections.unmodifiableSet(new java.util.HashSet<>(Arrays.asList(
+            "server", "externalConnection", "clientOrdinaryApplication", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "global", "privileged", "serverCall"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+    /**
+     * What the properties object still has to write itself.
+     * <p>
+     * The service arguments come out always: they steer the call and describe no object. The module
+     * flags come out ONLY for a common module, the one type that reads them as arguments of its own.
+     * </p>
+     * <p>
+     * <b>Taking the flags out for every type would drop a property named {@code server} on a
+     * catalogue without a word</b> - the silent loss this whole change exists to end, reintroduced
+     * one method away from where it was fixed. Caught reading the change back, not by a test, which
+     * is why there is one now.
+     * </p>
+     *
+     * @param declared the members of the properties object.
+     * @param isCommonModule whether the object being created is a common module.
+     * @return the properties to apply one by one, in the order they were given
+     */
+    static Map<String, String> propertiesToApply(Map<String, String> declared,
+        boolean isCommonModule)
+    {
+        Map<String, String> remaining = new LinkedHashMap<>(declared);
+        remaining.keySet().removeAll(SERVICE_ARGUMENTS);
+        if (isCommonModule)
+        {
+            remaining.keySet().removeAll(COMMON_MODULE_FLAGS);
+        }
+        return remaining;
+    }
+
+    /**
+     * Says which property was given twice with two different values.
+     *
+     * @param params the call's arguments.
+     * @param declared the members of the properties object.
+     * @return the refusal text, or <code>null</code> when nothing contradicts
+     */
+    static String contradictingProperty(Map<String, String> params,
+        Map<String, String> declared)
+    {
+        if (params == null || declared.isEmpty())
+        {
+            return null;
+        }
+        for (Map.Entry<String, String> given : declared.entrySet())
+        {
+            String named = params.get(given.getKey());
+            if (named != null && !named.equals(given.getValue()))
+            {
+                return "'" + given.getKey() + "' was given twice and the two disagree: " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "the argument says '" + named + "', properties says '" //$NON-NLS-1$ //$NON-NLS-2$
+                    + given.getValue() + "'. Nothing was created. Give it once, or give the same " //$NON-NLS-1$
+                    + "value in both."; //$NON-NLS-1$
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Writes one boolean flag, and fails the call when it cannot.
+     * <p>
+     * <b>This used to swallow every exception into a log line.</b> A flag the caller asked for
+     * could go unwritten - a setter renamed between EDT builds, a value the model refused - and
+     * {@code create_object} still answered success. Nothing in the answer said which flag was
+     * dropped; the log is not somewhere a caller looks, and by the time anyone read the file the
+     * module had already failed EDT's own check. Found by reconciliation on 01.09.
+     * </p>
+     * <p>
+     * Raised rather than collected: the caller creates the object in one transaction, and a flag
+     * that cannot be written has to stop that transaction before the object is attached, so
+     * nothing half-made reaches the configuration.
+     * </p>
+     *
+     * @param target the object being built.
+     * @param setter the setter's name.
+     * @param value the value to write.
+     */
     private static void setBooleanProperty(Object target, String setter, boolean value)
     {
         try
         {
             target.getClass().getMethod(setter, boolean.class).invoke(target, value);
         }
-        catch (Exception e)
+        catch (ReflectiveOperationException | RuntimeException notApplied)
         {
-            Activator.logWarning("CommonModule " + setter + " not applied: " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
+            throw new RuntimeException("CommonModule flag " + setter.substring(3) //$NON-NLS-1$
+                + " could not be written: " + notApplied.getMessage() //$NON-NLS-1$
+                + ". The module was not created.", notApplied); //$NON-NLS-1$
         }
     }
 
@@ -183,23 +278,46 @@ final class ObjectOps
                 .toJson();
         }
 
+        // A property named twice - once as an argument, once in the properties object - with two
+        // different values is a contradiction, and picking one of them silently would write
+        // something the caller did not ask for. Equal values are not a contradiction.
+        Map<String, String> declared = JsonUtils.extractObjectArgument(params, "properties"); //$NON-NLS-1$
+        String contradiction = contradictingProperty(params, declared);
+        if (contradiction != null)
+        {
+            return ToolResult.error(contradiction).toJson();
+        }
+        // Folded into the arguments rather than applied separately, so a flag written this way
+        // reaches the same defaulting the named argument goes through. Applying it afterwards
+        // would let the default for an unnamed context overwrite it.
+        Map<String, String> effective = new LinkedHashMap<>(params);
+        for (Map.Entry<String, String> given : declared.entrySet())
+        {
+            effective.putIfAbsent(given.getKey(), given.getValue());
+        }
+
         // 3.8.2: extension CommonModule guards (privileged, global+server). The flags are
         // hoisted to finals so the BM task below can also APPLY them to the created module
         // - without that the module is created with no execution context and fails EDT's
         // "common-module-type" check on UpdateDBCfg (hindsight A10).
         final boolean isCommonModule = "CommonModule".equals(englishType);
+
+        final Map<String, String> remaining = propertiesToApply(declared, isCommonModule);
+        // Named in the answer, because "success" on its own does not say which properties reached
+        // the object - and that is exactly what could not be told apart before.
+        final List<String> applied = new ArrayList<>();
         final Boolean cmPrivileged = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "privileged") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "privileged") : null; //$NON-NLS-1$
         final Boolean cmGlobal = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "global") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "global") : null; //$NON-NLS-1$
         final Boolean cmServer = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "server") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "server") : null; //$NON-NLS-1$
         final Boolean cmExternalConnection = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "externalConnection") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "externalConnection") : null; //$NON-NLS-1$
         final Boolean cmClientOrdinaryApplication = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "clientOrdinaryApplication") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "clientOrdinaryApplication") : null; //$NON-NLS-1$
         final Boolean cmServerCall = isCommonModule
-            ? JsonUtils.extractBooleanArgumentNullable(params, "serverCall") : null; //$NON-NLS-1$
+            ? JsonUtils.extractBooleanArgumentNullable(effective, "serverCall") : null; //$NON-NLS-1$
         if (isCommonModule)
         {
             try
@@ -268,6 +386,22 @@ final class ObjectOps
                     {
                         applyCommonModuleFlags(created, cmPrivileged, cmGlobal, cmServer,
                             cmExternalConnection, cmClientOrdinaryApplication, cmServerCall);
+                    }
+                    // Applied BEFORE the object joins the configuration and before it is attached
+                    // as a top object. A property that cannot be written then stops the call while
+                    // the object exists nowhere but in this transaction, so a refusal leaves no
+                    // half-made object behind - which is what "the whole request or none of it"
+                    // means here. A scheduled job created with a name and nothing else is the case
+                    // this exists for: it fails EDT's own check the moment it appears.
+                    for (Map.Entry<String, String> property : remaining.entrySet())
+                    {
+                        String refused =
+                            BmObjectHelper.setProperty(created, property.getKey(), property.getValue());
+                        if (refused != null)
+                        {
+                            throw new RuntimeException(refused + " Nothing was created."); //$NON-NLS-1$
+                        }
+                        applied.add(property.getKey());
                     }
                     if (!BmObjectHelper.addToConfiguration(config, created))
                     {
@@ -342,6 +476,7 @@ final class ObjectOps
             .put("operation", "create_object") //$NON-NLS-1$ //$NON-NLS-2$
             .put("objectType", englishType) //$NON-NLS-1$
             .put("name", name) //$NON-NLS-1$
+            .put("propertiesApplied", applied) //$NON-NLS-1$
             .put("dryRun", dryRun) //$NON-NLS-1$
             .put("message", dryRun //$NON-NLS-1$
                 ? "Dry run: " + englishType + "." + name + " would be created." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectOps.java
@@ -361,6 +361,8 @@ final class ObjectOps
         // the arguments belongs here too: it was asked for in the properties object and it was
         // written, and leaving it out would say the opposite of what happened.
         final List<String> applied = new ArrayList<>();
+        // Those among them the file will not carry, because the value is the model's own default.
+        final List<String> atModelDefault = new ArrayList<>();
         for (String property : declared.keySet())
         {
             if (!remaining.containsKey(property) && !SERVICE_ARGUMENTS.contains(property))
@@ -464,6 +466,14 @@ final class ObjectOps
                             throw new RuntimeException(refused + " Nothing was created."); //$NON-NLS-1$
                         }
                         applied.add(property.getKey());
+                        // A value the model already had as its default is not serialized, so it
+                        // reaches the object and the file shows nothing. Said out loud, because a
+                        // reader comparing the answer with the diff otherwise sees a property lost
+                        // on the way. Measured live 01.09 on a scheduled job's use=false.
+                        if (BmObjectHelper.equalsModelDefault(created, property.getKey()))
+                        {
+                            atModelDefault.add(property.getKey());
+                        }
                     }
                     if (!BmObjectHelper.addToConfiguration(config, created))
                     {
@@ -543,6 +553,13 @@ final class ObjectOps
             .put("message", dryRun //$NON-NLS-1$
                 ? "Dry run: " + englishType + "." + name + " would be created." //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                 : englishType + "." + name + " created."); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!atModelDefault.isEmpty())
+        {
+            ok.put("propertiesAtModelDefault", atModelDefault) //$NON-NLS-1$
+                .put("propertiesAtModelDefaultNote", "these carry the value the model already had, " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "so EDT writes nothing for them and the file will not show them. They did " //$NON-NLS-1$
+                    + "reach the object."); //$NON-NLS-1$
+        }
         // Expose synonym outcome so the agent does not have to guess - explicit
         // value, auto-generated value, or a setter failure are all reported.
         EditMetadataTool.SynonymResult sr = synonymRef.get();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/JsonUtils.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/JsonUtils.java
@@ -194,6 +194,57 @@ public final class JsonUtils
     }
 
     /**
+     * Reads an argument that carries a JSON object of name to scalar value.
+     * <p>
+     * A tool is handed text, so a nested object arrives as its compact JSON form and has to be
+     * parsed back. Only primitive members are taken, each in its string form: a nested object or
+     * array under a property name has no meaning for the callers of this - they set one value per
+     * property - and taking it would hand the setter a string of JSON.
+     * </p>
+     * <p>
+     * Insertion order is kept, so a refusal names the properties in the order the caller wrote
+     * them rather than in whatever order a hash landed on.
+     * </p>
+     *
+     * @param params the tool parameters; may be <code>null</code>
+     * @param argumentName the argument name
+     * @return the members in the order given, or an empty map when the argument is missing, empty,
+     *         not an object, or carries no primitive member
+     */
+    public static Map<String, String> extractObjectArgument(Map<String, String> params,
+        String argumentName)
+    {
+        String raw = extractStringArgument(params, argumentName);
+        if (raw == null || raw.trim().isEmpty())
+        {
+            return new java.util.LinkedHashMap<>();
+        }
+        Map<String, String> members = new java.util.LinkedHashMap<>();
+        try
+        {
+            JsonElement parsed = JsonParser.parseString(raw.trim());
+            if (!parsed.isJsonObject())
+            {
+                return members;
+            }
+            for (Map.Entry<String, JsonElement> member : parsed.getAsJsonObject().entrySet())
+            {
+                if (member.getValue().isJsonPrimitive())
+                {
+                    members.put(member.getKey(), member.getValue().getAsString());
+                }
+            }
+        }
+        catch (RuntimeException notJson)
+        {
+            // A value that does not parse carries nothing this can use. The caller reports the
+            // argument as unusable; guessing at a shape here would invent members nobody wrote.
+            return new java.util.LinkedHashMap<>();
+        }
+        return members;
+    }
+
+    /**
      * Reads a list argument, accepting either spelling clients use: a JSON array
      * (<code>["a","b"]</code>) or a comma-separated string (<code>a, b</code>).
      * <p>

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/JsonUtils.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/JsonUtils.java
@@ -245,6 +245,58 @@ public final class JsonUtils
     }
 
     /**
+     * Says why an object argument cannot be used, when one was supplied at all.
+     * <p>
+     * {@link #extractObjectArgument} is forgiving on purpose: text that is not an object reads as
+     * no members, which is right for a caller that wants to look and move on. It is wrong for a
+     * caller that promises all of the request or none of it - there, "nothing came back" and
+     * "nothing was asked" have to be told apart, or a malformed object silently becomes an object
+     * nobody asked for. Ask this first, and refuse before doing any work.
+     * </p>
+     *
+     * @param params the tool parameters; may be <code>null</code>
+     * @param argumentName the argument name
+     * @return the reason, or <code>null</code> when the argument is absent or fully usable
+     */
+    public static String objectArgumentProblem(Map<String, String> params, String argumentName)
+    {
+        String raw = extractStringArgument(params, argumentName);
+        if (raw == null || raw.trim().isEmpty())
+        {
+            return null;
+        }
+        JsonElement parsed;
+        try
+        {
+            parsed = JsonParser.parseString(raw.trim());
+        }
+        catch (RuntimeException notJson)
+        {
+            return "'" + argumentName + "' is not JSON: " + notJson.getMessage(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        if (!parsed.isJsonObject())
+        {
+            return "'" + argumentName + "' has to be a JSON object of name to value, and this is " //$NON-NLS-1$ //$NON-NLS-2$
+                + (parsed.isJsonArray() ? "an array." : "not one."); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        List<String> unusable = new ArrayList<>();
+        for (Map.Entry<String, JsonElement> member : parsed.getAsJsonObject().entrySet())
+        {
+            if (!member.getValue().isJsonPrimitive())
+            {
+                unusable.add(member.getKey());
+            }
+        }
+        if (!unusable.isEmpty())
+        {
+            return "'" + argumentName + "' carries a value that is not a single value for: " //$NON-NLS-1$ //$NON-NLS-2$
+                + String.join(", ", unusable) //$NON-NLS-1$
+                + ". Each name takes one value - text, a number or true/false."; //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
      * Reads a list argument, accepting either spelling clients use: a JSON array
      * (<code>["a","b"]</code>) or a comma-separated string (<code>a, b</code>).
      * <p>

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/SchemaComposer.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/SchemaComposer.java
@@ -202,6 +202,27 @@ public class SchemaComposer
     }
 
     /**
+     * Declares a parameter whose value is an object of names to scalar values.
+     * <p>
+     * Declared as an object rather than as a string carrying JSON, because a client that builds
+     * calls from the schema goes by the declared type: told "string", it either refuses the object
+     * the description asks for or encodes it twice, and the tool then reads a quoted blob instead
+     * of members.
+     * </p>
+     *
+     * @param name the parameter name
+     * @param description what the parameter means, as the client will show it
+     * @return this builder
+     */
+    public SchemaComposer objectProperty(String name, String description)
+    {
+        Map<String, Object> definition = new LinkedHashMap<>();
+        definition.put(KEY_TYPE, TYPE_OBJECT);
+        definition.put(KEY_DESCRIPTION, description);
+        return addProperty(name, definition, false);
+    }
+
+    /**
      * Renders the schema.
      * <p>
      * {@code properties} and {@code required} are always present, empty if nothing was declared.

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AFlagNameOnAnotherTypeIsAPropertyTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AFlagNameOnAnotherTypeIsAPropertyTest.java
@@ -7,6 +7,8 @@
 package ru.aiedt.mcp.server.toolkit.ops;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -90,5 +92,47 @@ public class AFlagNameOnAnotherTypeIsAPropertyTest
     {
         assertTrue(ObjectOps.propertiesToApply(map(), false).isEmpty());
         assertTrue(ObjectOps.propertiesToApply(map(), true).isEmpty());
+    }
+
+    /**
+     * A folded flag never reaches the generic setter, so nothing downstream would refuse a value
+     * the boolean reader cannot read. It answers "not given" to anything outside true/false, and
+     * "not given" is what a flag the caller left out looks like - so the default context would be
+     * written and the call would succeed as though the property had not been asked for.
+     */
+    @Test
+    public void aFlagValueThatIsNotBooleanIsRefused()
+    {
+        String refused = ObjectOps.unreadableFlag(map("server", "tru"), true);
+        assertNotNull(refused);
+        assertTrue(refused.contains("server"));
+        assertTrue(refused.contains("tru"));
+        assertTrue(refused.contains("Nothing was created"));
+    }
+
+    @Test
+    public void theSpellingsTheReaderAcceptsPassThrough()
+    {
+        for (String spelling : new String[] { "true", "false", "1", "0", "yes", "no", "TRUE" })
+        {
+            assertNull("'" + spelling + "' is a value the reader takes",
+                ObjectOps.unreadableFlag(map("global", spelling), true));
+        }
+    }
+
+    /**
+     * On any other type the same name is an ordinary property, and the generic setter judges the
+     * value. Refusing it here would reject a property the object may well have.
+     */
+    @Test
+    public void aFlagValueIsNotJudgedOnAnotherType()
+    {
+        assertNull(ObjectOps.unreadableFlag(map("server", "tru"), false));
+    }
+
+    @Test
+    public void aPropertyThatIsNotAFlagIsNotJudgedHere()
+    {
+        assertNull(ObjectOps.unreadableFlag(map("methodName", "CommonModule.A.B"), true));
     }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AFlagNameOnAnotherTypeIsAPropertyTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AFlagNameOnAnotherTypeIsAPropertyTest.java
@@ -1,0 +1,94 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Which members of the properties object {@code create_object} still has to write itself.
+ * <p>
+ * A common module reads its execution contexts as arguments of its own, so a properties object
+ * carrying one of those names is folded into the arguments instead of being applied twice. No other
+ * type reads them, so on any other type a property of the same name is an ordinary property.
+ * </p>
+ * <p>
+ * The first version of the change took those names out for EVERY type, which would have dropped a
+ * property named {@code server} on a catalogue in silence - the loss the change exists to end,
+ * reintroduced one method away from the fix. It was caught reading the change back rather than by a
+ * test, so this is that test.
+ * </p>
+ */
+public class AFlagNameOnAnotherTypeIsAPropertyTest
+{
+    private static Map<String, String> map(String... pairs)
+    {
+        Map<String, String> built = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < pairs.length; i += 2)
+        {
+            built.put(pairs[i], pairs[i + 1]);
+        }
+        return built;
+    }
+
+    @Test
+    public void aFlagNameSurvivesOnAnotherType()
+    {
+        Map<String, String> toApply =
+            ObjectOps.propertiesToApply(map("server", "true", "use", "false"), false);
+        assertTrue("a catalogue has no 'server' argument, so this one has to be applied",
+            toApply.containsKey("server"));
+        assertEquals(2, toApply.size());
+    }
+
+    @Test
+    public void aFlagNameIsFoldedAwayOnACommonModule()
+    {
+        Map<String, String> toApply =
+            ObjectOps.propertiesToApply(map("server", "true", "comment", "x"), true);
+        assertEquals("the module reads it as an argument; applying it again would write it twice",
+            map("comment", "x"), toApply);
+    }
+
+    /** Service arguments steer the call and describe no object, whatever the type. */
+    @Test
+    public void serviceArgumentsComeOutForEveryType()
+    {
+        for (boolean isCommonModule : new boolean[] { true, false })
+        {
+            Map<String, String> toApply = ObjectOps.propertiesToApply(
+                map("projectName", "P", "objectType", "Catalog", "name", "X", "synonym", "Y",
+                    "dryRun", "true", "properties", "{}", "comment", "kept"),
+                isCommonModule);
+            assertEquals("only the real property is left", map("comment", "kept"), toApply);
+        }
+    }
+
+    /** A refusal names the properties in the order the caller wrote them. */
+    @Test
+    public void theOrderGivenSurvives()
+    {
+        Map<String, String> toApply =
+            ObjectOps.propertiesToApply(map("zebra", "1", "alpha", "2", "middle", "3"), false);
+        assertEquals(new ArrayList<>(Arrays.asList("zebra", "alpha", "middle")),
+            new ArrayList<>(toApply.keySet()));
+    }
+
+    @Test
+    public void nothingDeclaredLeavesNothingToApply()
+    {
+        assertTrue(ObjectOps.propertiesToApply(map(), false).isEmpty());
+        assertTrue(ObjectOps.propertiesToApply(map(), true).isEmpty());
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/APropertyGivenTwiceMustAgreeTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/APropertyGivenTwiceMustAgreeTest.java
@@ -1,0 +1,81 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * What happens when a property is named as an argument and again in the properties object.
+ * <p>
+ * {@code create_object} reads some properties as arguments of their own - the execution contexts of
+ * a common module among them - and now also takes a properties object. A property in both places
+ * with two different values is a contradiction, and choosing one of them quietly would write
+ * something the caller did not ask for.
+ * </p>
+ */
+public class APropertyGivenTwiceMustAgreeTest
+{
+    private static Map<String, String> map(String... pairs)
+    {
+        Map<String, String> built = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < pairs.length; i += 2)
+        {
+            built.put(pairs[i], pairs[i + 1]);
+        }
+        return built;
+    }
+
+    @Test
+    public void twoValuesForOnePropertyAreRefused()
+    {
+        String refused = ObjectOps.contradictingProperty(map("server", "true"),
+            map("server", "false"));
+        assertNotNull("a property given twice with two values has to stop the call", refused);
+        assertTrue("the refusal names the property", refused.contains("server"));
+        assertTrue("and both values, so the caller can see which to drop",
+            refused.contains("true") && refused.contains("false"));
+        assertTrue("and says the object was not created", refused.contains("Nothing was created"));
+    }
+
+    /** The same value twice is not a contradiction: the caller asked for one thing, twice. */
+    @Test
+    public void theSameValueTwiceIsNotAContradiction()
+    {
+        assertNull(ObjectOps.contradictingProperty(map("server", "true"), map("server", "true")));
+    }
+
+    @Test
+    public void propertiesThatDoNotOverlapPassThrough()
+    {
+        assertNull(ObjectOps.contradictingProperty(map("name", "X", "server", "true"),
+            map("methodName", "CommonModule.A.B", "use", "false")));
+    }
+
+    @Test
+    public void nothingToCompareIsNotAContradiction()
+    {
+        assertNull(ObjectOps.contradictingProperty(map("name", "X"), map()));
+        assertNull(ObjectOps.contradictingProperty(null, map("use", "false")));
+    }
+
+    /** The first disagreement is enough to stop; the answer names one property, not a list. */
+    @Test
+    public void theFirstDisagreementIsReported()
+    {
+        String refused = ObjectOps.contradictingProperty(map("server", "true", "global", "true"),
+            map("global", "false"));
+        assertNotNull(refused);
+        assertTrue(refused.contains("global"));
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/wire/AnObjectArgumentIsReadBackTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/wire/AnObjectArgumentIsReadBackTest.java
@@ -1,0 +1,94 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.wire;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * What comes back from an argument that carries a JSON object.
+ * <p>
+ * A tool is handed text, so a nested object arrives as its compact JSON form. Reading it back is
+ * what lets {@code create_object} take a set of properties in one call instead of one argument per
+ * property, which is why a scheduled job could be created with a name and nothing else.
+ * </p>
+ */
+public class AnObjectArgumentIsReadBackTest
+{
+    private static Map<String, String> withProperties(String raw)
+    {
+        Map<String, String> params = new HashMap<>();
+        if (raw != null)
+        {
+            params.put("properties", raw);
+        }
+        return params;
+    }
+
+    @Test
+    public void membersComeBackAsText()
+    {
+        Map<String, String> read = JsonUtils.extractObjectArgument(
+            withProperties("{\"methodName\":\"CommonModule.A.B\",\"use\":false,\"restarts\":3}"),
+            "properties");
+        assertEquals(3, read.size());
+        assertEquals("CommonModule.A.B", read.get("methodName"));
+        assertEquals("false", read.get("use"));
+        assertEquals("3", read.get("restarts"));
+    }
+
+    /** A refusal names the properties in the order they were written, not in a hash order. */
+    @Test
+    public void theOrderGivenIsKept()
+    {
+        Map<String, String> read = JsonUtils.extractObjectArgument(
+            withProperties("{\"zebra\":\"1\",\"alpha\":\"2\",\"middle\":\"3\"}"), "properties");
+        assertEquals(new ArrayList<>(java.util.Arrays.asList("zebra", "alpha", "middle")),
+            new ArrayList<>(read.keySet()));
+    }
+
+    /**
+     * A member that is itself an object or an array has no meaning for a property setter, and
+     * handing it over would pass a string of JSON as the value.
+     */
+    @Test
+    public void aNestedMemberIsLeftOut()
+    {
+        Map<String, String> read = JsonUtils.extractObjectArgument(
+            withProperties("{\"use\":true,\"nested\":{\"a\":1},\"list\":[1,2]}"), "properties");
+        assertEquals(1, read.size());
+        assertTrue(read.containsKey("use"));
+    }
+
+    @Test
+    public void nothingGivenReadsAsNothingAsked()
+    {
+        assertTrue(JsonUtils.extractObjectArgument(withProperties(null), "properties").isEmpty());
+        assertTrue(JsonUtils.extractObjectArgument(withProperties(""), "properties").isEmpty());
+        assertTrue(JsonUtils.extractObjectArgument(withProperties("   "), "properties").isEmpty());
+    }
+
+    /**
+     * Text that is not an object carries nothing usable. Guessing a shape here would invent
+     * properties nobody wrote and apply them to the object.
+     */
+    @Test
+    public void whatIsNotAnObjectYieldsNothing()
+    {
+        assertTrue(JsonUtils.extractObjectArgument(withProperties("[1,2]"), "properties").isEmpty());
+        assertTrue(JsonUtils.extractObjectArgument(withProperties("plain text"), "properties")
+            .isEmpty());
+        assertTrue(JsonUtils.extractObjectArgument(withProperties("{broken"), "properties")
+            .isEmpty());
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/wire/AnObjectArgumentIsReadBackTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/wire/AnObjectArgumentIsReadBackTest.java
@@ -7,6 +7,8 @@
 package ru.aiedt.mcp.server.wire;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -90,5 +92,47 @@ public class AnObjectArgumentIsReadBackTest
             .isEmpty());
         assertTrue(JsonUtils.extractObjectArgument(withProperties("{broken"), "properties")
             .isEmpty());
+    }
+
+    /**
+     * Reading leniently is right for a caller that wants to look; it is wrong for one that
+     * promises all of the request or none of it. Those two answers - "nothing came back" and
+     * "nothing was asked" - are the same map, so a caller has to be able to ask which it was.
+     */
+    @Test
+    public void nothingSuppliedIsNotAProblem()
+    {
+        assertNull(JsonUtils.objectArgumentProblem(withProperties(null), "properties"));
+        assertNull(JsonUtils.objectArgumentProblem(withProperties(""), "properties"));
+        assertNull(JsonUtils.objectArgumentProblem(withProperties("{}"), "properties"));
+        assertNull(JsonUtils.objectArgumentProblem(withProperties("{\"use\":false}"), "properties"));
+    }
+
+    @Test
+    public void textThatIsNotJsonIsAProblem()
+    {
+        String said = JsonUtils.objectArgumentProblem(withProperties("{broken"), "properties");
+        assertNotNull("a malformed object must not read as no properties at all", said);
+        assertTrue(said.contains("properties"));
+    }
+
+    @Test
+    public void jsonThatIsNotAnObjectIsAProblem()
+    {
+        assertNotNull(JsonUtils.objectArgumentProblem(withProperties("[1,2]"), "properties"));
+        assertTrue(JsonUtils.objectArgumentProblem(withProperties("[1,2]"), "properties")
+            .contains("array"));
+        assertNotNull(JsonUtils.objectArgumentProblem(withProperties("\"text\""), "properties"));
+    }
+
+    /** A member that was going to be dropped is named, rather than quietly left out. */
+    @Test
+    public void aMemberThatIsNotOneValueIsNamed()
+    {
+        String said = JsonUtils.objectArgumentProblem(
+            withProperties("{\"use\":true,\"nested\":{\"a\":1},\"list\":[1,2]}"), "properties");
+        assertNotNull(said);
+        assertTrue(said.contains("nested"));
+        assertTrue(said.contains("list"));
     }
 }


### PR DESCRIPTION
`create_object` read nothing but the name, the synonym and a common module's execution contexts. A scheduled job therefore appeared with a name and nothing else and failed EDT's own check the moment it did: the method name it must carry could not be given at creation.

It now reads a `properties` object of name to value. The properties are applied **before** the object joins the configuration and before it is attached as a top object, so a property that cannot be written stops the call while the object exists nowhere but in the transaction. A refusal leaves nothing half-made behind, and no compensating delete is needed.

Refused, rather than quietly accepted:

- a properties object that was sent and cannot be used - not JSON, not an object, or a member holding a structure. The reader is forgiving by design, and leaning on that while promising all-or-nothing turned a malformed object into a bare one with a successful answer;
- a property named both as an argument and in the object with two different values, naming both;
- a common-module flag whose value the boolean reader does not recognise. It never reaches the generic setter, so `{"server":"tru"}` wrote the default context and answered success.

`setBooleanProperty` no longer swallows a setter failure into a log line: a flag the caller asked for could go unwritten while the call answered success.

The flag names come out of the properties object only for a common module, the one type that reads them as arguments. Taking them out for every type would drop a property named `server` on a catalogue without a word.

`propertiesApplied` names what reached the object, folded flags included.

The operation map regains the three named-area operations along the way: it is derived from the sources and had not been rewritten since they shipped.

Build: 2016 tests, no failures. All eight gates pass.

Not yet verified on a running stand - the live check is outstanding.
