### PR TITLE
Keep the snapshot a merge may need and remove the ones it will not

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -508,7 +508,7 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-2026 test methods across 211 test classes; 113 classes have a test of their own, median 9 methods each.
+2028 test methods across 211 test classes; 113 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 379 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 113 | a test class named after it |
-| exercised | 63 | reached by some other test |
+| exercised | 64 | reached by some other test |
 | tool-sweep | 90 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 62 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **378** | across 210 test classes |
+| **total** | **379** | across 211 test classes |
 
 ## untested (0)
 
@@ -267,7 +267,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (63)
+## exercised (64)
 
 **(root)**
 - Activator
@@ -312,6 +312,7 @@ _none_
 - PendingWorkRegistry
 - ProjectStateGuard
 - QlValidator
+- SupportSnapshotStore
 - UnreadArguments
 
 **toolkit**
@@ -507,9 +508,9 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-2016 test methods across 210 test classes; 113 classes have a test of their own, median 9 methods each.
+2026 test methods across 211 test classes; 113 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 378 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 379 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/docs/tools/operation-parameters.md
+++ b/docs/tools/operation-parameters.md
@@ -247,8 +247,10 @@
 | `SyncControlTool` | `diagnose` | `projectName` | passed in as locals |
 | `SyncControlTool` | `diagnose_delta` | `projectName` | passed in as locals |
 | `SyncControlTool` | `diagnose_stuck_locks` | `projectName` | passed in as locals |
+| `SyncControlTool` | `list_support_snapshots` | `projectName` | passed in as locals |
 | `SyncControlTool` | `mark_synchronized` | `projectName` | passed in as locals |
-| `SyncControlTool` | `recover_stuck_merge` | `operation`, `projectName` | passed in as locals |
+| `SyncControlTool` | `recover_stuck_merge` | `projectName` | passed in as locals |
+| `SyncControlTool` | `release_support_snapshot` | `operation`, `projectName` | passed in as locals |
 | `SyncControlTool` | `reseed_baseline` | `projectName` | passed in as locals |
 | `SyncControlTool` | `status` | `projectName` | passed in as locals |
 | `SyncControlTool` | `suppress` | `projectName` | passed in as locals |

--- a/mcp/bundles/ru.aiedt.mcp.server/schema/operation-parameters.tsv
+++ b/mcp/bundles/ru.aiedt.mcp.server/schema/operation-parameters.tsv
@@ -240,8 +240,10 @@ SupportRegistryTool	status	projectName	passed in as locals
 SyncControlTool	diagnose	projectName	passed in as locals
 SyncControlTool	diagnose_delta	projectName	passed in as locals
 SyncControlTool	diagnose_stuck_locks	projectName	passed in as locals
+SyncControlTool	list_support_snapshots	projectName	passed in as locals
 SyncControlTool	mark_synchronized	projectName	passed in as locals
-SyncControlTool	recover_stuck_merge	operation,projectName	passed in as locals
+SyncControlTool	recover_stuck_merge	projectName	passed in as locals
+SyncControlTool	release_support_snapshot	operation,projectName	passed in as locals
 SyncControlTool	reseed_baseline	projectName	passed in as locals
 SyncControlTool	status	projectName	passed in as locals
 SyncControlTool	suppress	projectName	passed in as locals

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/McpAutoStart.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/McpAutoStart.java
@@ -10,6 +10,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.IStartup;
 
 import ru.aiedt.mcp.server.settings.PrefKeys;
+import ru.aiedt.mcp.server.support.SupportSnapshotStore;
 import ru.aiedt.mcp.server.upkeep.ReleaseSweep;
 
 /**
@@ -63,6 +64,12 @@ public class McpAutoStart
             // told. It never throws, so the endpoint below is not at its mercy.
             ReleaseSweep.get().start();
 
+            // The second of the two moments cleanup runs; the other is when a merge settles.
+            // A session that ended without settling one leaves its snapshot behind, and the
+            // next start is the first chance anything has to look. Protected snapshots are
+            // left alone here as everywhere: only the ordinary ones past the limit go.
+            pruneSupportSnapshots();
+
             if (!preferences.getBoolean(PrefKeys.PREF_AUTO_START))
             {
                 return;
@@ -79,6 +86,42 @@ public class McpAutoStart
         catch (Exception e)
         {
             Activator.logError("AI-EDT endpoint could not come up automatically", e); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * Removes the ordinary support snapshots that sit past the limit, in every open project.
+     * <p>
+     * Never throws and never blocks the rest of start-up: a directory that cannot be read is one
+     * project's snapshots left where they are, which costs disk and nothing else.
+     * </p>
+     */
+    private static void pruneSupportSnapshots()
+    {
+        try
+        {
+            int removed = 0;
+            for (org.eclipse.core.resources.IProject project : org.eclipse.core.resources.ResourcesPlugin
+                .getWorkspace().getRoot().getProjects())
+            {
+                if (!project.isOpen() || project.getLocation() == null)
+                {
+                    continue;
+                }
+                removed += SupportSnapshotStore.prune(
+                    project.getLocation().toFile().toPath().resolve(".settings"), //$NON-NLS-1$
+                    SupportSnapshotStore.KEPT);
+            }
+            if (removed > 0)
+            {
+                Activator.logInfo("Removed " + removed + " support snapshot(s) past the limit of " //$NON-NLS-1$ //$NON-NLS-2$
+                    + SupportSnapshotStore.KEPT + "; protected ones were left."); //$NON-NLS-1$
+            }
+        }
+        catch (Exception | LinkageError cannotSweep)
+        {
+            Activator.logWarning("support snapshots could not be swept at start-up: " //$NON-NLS-1$
+                + cannotSweep);
         }
     }
 }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
@@ -2628,8 +2628,11 @@ public final class BmComparisonHelper
      */
     static void settleSnapshotAfterMerge(String projectName, Outcome outcome)
     {
-        if (outcome.supportSnapshotFile == null || outcome.mergeRefused != null
-            || outcome.writeMayHaveStarted)
+        // Gated on the merge having FINISHED, not on whether writing began. writeMayHaveStarted is
+        // raised before startMerge for every merge, successful ones included - it exists to say
+        // "assume nothing is untouched from here" - so reading it as "the outcome is unknown" made
+        // this method return every time and settled nothing at all.
+        if (outcome.supportSnapshotFile == null || outcome.mergeRefused != null || !outcome.merged)
         {
             return;
         }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
@@ -941,6 +941,18 @@ public final class BmComparisonHelper
          */
         public String supportSnapshotFile;
 
+        /** How many ordinary snapshots the limit removed once this merge settled. */
+        public int supportSnapshotsRemoved;
+
+        /**
+         * Snapshots this project holds that cleanup will not touch, by file name.
+         * <p>
+         * Named in the answer rather than counted, because after a restart a count is
+         * nothing to act on: releasing one needs the file it belongs to.
+         * </p>
+         */
+        public java.util.List<String> supportSnapshotsHeld;
+
         /**
          * Objects whose own content did not survive the merge, named.
          * <p>
@@ -1275,6 +1287,7 @@ public final class BmComparisonHelper
             }
             reportProjectState(mainProjectName, decisions, outcome);
             dropSnapshotNothingNeeds(outcome);
+            settleSnapshotAfterMerge(mainProjectName, outcome);
             // A reporting comparison stays open, and its key goes out with the answer. Paging
             // through tens of thousands of changed objects is the only way to enumerate what to
             // protect, and closing here would charge a full comparison for every page. Only a
@@ -2597,6 +2610,54 @@ public final class BmComparisonHelper
      */
     // Package-visible for the test: the decision it makes is what stands between a stray megabyte
     // and a lost support model, and it is reachable no other way without running a real merge.
+    /**
+     * Settles the snapshot once the merge has reached a known state.
+     * <p>
+     * A merge that finished is a known state, so the snapshot it took stops being the only way back
+     * and becomes an ordinary one - subject to the limit, like the ones before it. A merge whose
+     * outcome is not known keeps its protection, and only a person takes it off.
+     * </p>
+     * <p>
+     * Cleanup runs here rather than before a snapshot is taken. Cleaning ahead would remove the
+     * previous way back for a merge that then refuses before writing anything, leaving the project
+     * with neither.
+     * </p>
+     *
+     * @param projectName the project whose snapshots are being settled.
+     * @param outcome the answer being built.
+     */
+    static void settleSnapshotAfterMerge(String projectName, Outcome outcome)
+    {
+        if (outcome.supportSnapshotFile == null || outcome.mergeRefused != null
+            || outcome.writeMayHaveStarted)
+        {
+            return;
+        }
+        Path file = Paths.get(outcome.supportSnapshotFile);
+        String stillProtected = SupportSnapshotStore.clearProtection(file);
+        if (stillProtected != null)
+        {
+            outcome.supportSnapshotKeptBecause = stillProtected;
+            return;
+        }
+        Path settings = file.getParent();
+        int removed = SupportSnapshotStore.prune(settings, SupportSnapshotStore.KEPT);
+        if (removed > 0)
+        {
+            outcome.supportSnapshotsRemoved = removed;
+        }
+        List<Path> held = SupportSnapshotStore.protectedIn(settings);
+        if (!held.isEmpty())
+        {
+            List<String> names = new ArrayList<>();
+            for (Path one : held)
+            {
+                names.add(one.getFileName().toString());
+            }
+            outcome.supportSnapshotsHeld = names;
+        }
+    }
+
     static void dropSnapshotNothingNeeds(Outcome outcome)
     {
         if (outcome.supportSnapshotFile == null || outcome.mergeRefused == null)
@@ -2676,7 +2737,15 @@ public final class BmComparisonHelper
             Path staging = settings.resolve(path.getFileName() + ".writing"); //$NON-NLS-1$
             try
             {
-                snapshot.write(staging);
+                // Published ALREADY protected, and the mark is inside the file, so there is no
+                // instant at which a snapshot exists without it. Marking after the move would leave
+                // a window: a crash inside it produces a snapshot cleanup takes for an ordinary one
+                // and removes - the only way back, gone, in the one case it is needed.
+                //
+                // Pessimistic on purpose. Protection comes off only when the merge settles into a
+                // known state; any crash therefore leaves it on, at the cost of a file and one
+                // deliberate act by a person.
+                snapshot.write(staging, true);
                 try
                 {
                     java.nio.file.Files.move(staging, path,

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshot.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshot.java
@@ -35,6 +35,9 @@ public final class SupportSnapshot
     /** First line of the file, so a wrong file is refused rather than half-read. */
     static final String HEADER = "# AI-EDT support mode snapshot v1"; //$NON-NLS-1$
 
+    /** Marks a snapshot that cleanup must not remove. See {@link #write(Path, boolean)}. */
+    static final String PROTECTED = "# protected"; //$NON-NLS-1$
+
     private static final String VENDOR = "# vendor\t"; //$NON-NLS-1$
 
     private static final String PROJECT = "# project\t"; //$NON-NLS-1$
@@ -349,8 +352,35 @@ public final class SupportSnapshot
      */
     public void write(Path path) throws IOException
     {
+        write(path, false);
+    }
+
+    /**
+     * Writes the snapshot, optionally marked as the only way back.
+     * <p>
+     * The mark goes into the file rather than beside it, because the file is published by moving it
+     * into place: a mark written afterwards would leave a window in which a crash produces a
+     * snapshot the cleanup takes for an ordinary one and deletes. Written inside, it is there the
+     * instant the snapshot exists.
+     * </p>
+     * <p>
+     * It is a comment line, which every reader of this format already skips, so a snapshot marked
+     * by this build still restores through an older one.
+     * </p>
+     *
+     * @param path where to write.
+     * @param protectedSnapshot whether the snapshot must survive cleanup until someone says the
+     *            merge it belongs to has been dealt with.
+     * @throws IOException when the file cannot be written
+     */
+    public void write(Path path, boolean protectedSnapshot) throws IOException
+    {
         List<String> lines = new ArrayList<>();
         lines.add(HEADER);
+        if (protectedSnapshot)
+        {
+            lines.add(PROTECTED);
+        }
         lines.add(PROJECT + projectName);
         lines.add("# objects no longer in the configuration\t" + unresolved); //$NON-NLS-1$
         for (Parent parent : parents)

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshotStore.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshotStore.java
@@ -68,7 +68,10 @@ public final class SupportSnapshotStore
         {
             for (Path entry : entries)
             {
-                found.add(entry);
+                if (isSnapshotName(entry.getFileName().toString()))
+                {
+                    found.add(entry);
+                }
             }
         }
         catch (IOException | RuntimeException cannotList)
@@ -79,6 +82,32 @@ public final class SupportSnapshotStore
         }
         found.sort(Comparator.comparing((Path p) -> p.getFileName().toString()).reversed());
         return found;
+    }
+
+    /**
+     * Whether the file name is a merge snapshot rather than something named after one.
+     * <p>
+     * <b>The pattern alone is not enough.</b> Restoring support modes writes its undo record beside
+     * the snapshot it restored from, as {@code <snapshot>.before-restore.tsv} - which begins with
+     * the same prefix and ends with the same extension. That record is the only way to reverse a
+     * restore, and cleanup counting it as an ordinary snapshot would delete exactly that.
+     * </p>
+     * <p>
+     * A snapshot's own name carries one dot, the one before the extension. Anything with more has
+     * been named after a snapshot by something else.
+     * </p>
+     *
+     * @param fileName the file's name, without a directory.
+     * @return <code>true</code> when this is a merge snapshot
+     */
+    static boolean isSnapshotName(String fileName)
+    {
+        if (fileName == null || !fileName.startsWith(PREFIX) || !fileName.endsWith(SUFFIX))
+        {
+            return false;
+        }
+        String stamp = fileName.substring(PREFIX.length(), fileName.length() - SUFFIX.length());
+        return !stamp.isEmpty() && stamp.indexOf('.') < 0;
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshotStore.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/SupportSnapshotStore.java
@@ -1,0 +1,243 @@
+/**
+ * AI-EDT - 1C AI tools for EDT
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import ru.aiedt.mcp.server.Activator;
+
+/**
+ * The snapshots of support modes a project has accumulated, and what may be removed.
+ * <p>
+ * Every successful merge leaves one - around a megabyte and a half on a configuration of nine
+ * thousand objects - and nothing ever removed them: five were lying in one project before an
+ * experiment on 25.08. They are not litter, though. A snapshot is the only way to put the support
+ * model back, so the question is not how to delete them but which one may go.
+ * </p>
+ * <p>
+ * <b>Unknown counts as protected.</b> A file that cannot be read, or that carries no legible mark,
+ * is left alone. The alternative reading - "no mark, so ordinary" - would delete exactly the file a
+ * crash left half-published, which is the one case where the snapshot matters most.
+ * </p>
+ */
+public final class SupportSnapshotStore
+{
+    /** How many ordinary snapshots a project keeps. Protected ones are not counted. */
+    public static final int KEPT = 3;
+
+    private static final String PREFIX = "aiedt-support-snapshot-"; //$NON-NLS-1$
+
+    private static final String SUFFIX = ".tsv"; //$NON-NLS-1$
+
+    private SupportSnapshotStore()
+    {
+    }
+
+    /**
+     * The snapshots a project holds, newest name first.
+     * <p>
+     * Ordered by file name rather than by modification time: the name carries the moment the
+     * snapshot was taken, and a copy or a restore rewrites the timestamp while leaving the name
+     * alone.
+     * </p>
+     *
+     * @param settings the project's settings directory.
+     * @return the snapshot files, or an empty list when there are none or the directory cannot be
+     *         read
+     */
+    public static List<Path> list(Path settings)
+    {
+        List<Path> found = new ArrayList<>();
+        if (settings == null || !Files.isDirectory(settings))
+        {
+            return found;
+        }
+        try (DirectoryStream<Path> entries = Files.newDirectoryStream(settings, PREFIX + "*" + SUFFIX)) //$NON-NLS-1$
+        {
+            for (Path entry : entries)
+            {
+                found.add(entry);
+            }
+        }
+        catch (IOException | RuntimeException cannotList)
+        {
+            Activator.logWarning("support snapshots could not be listed in " + settings //$NON-NLS-1$
+                + ": " + cannotList.getMessage()); //$NON-NLS-1$
+            return new ArrayList<>();
+        }
+        found.sort(Comparator.comparing((Path p) -> p.getFileName().toString()).reversed());
+        return found;
+    }
+
+    /**
+     * Whether this snapshot must survive cleanup.
+     *
+     * @param file the snapshot.
+     * @return <code>true</code> when it is marked, and when it cannot be read at all
+     */
+    public static boolean isProtected(Path file)
+    {
+        if (file == null)
+        {
+            return false;
+        }
+        try
+        {
+            for (String line : Files.readAllLines(file, StandardCharsets.UTF_8))
+            {
+                if (SupportSnapshot.PROTECTED.equals(line.trim()))
+                {
+                    return true;
+                }
+                if (!line.startsWith("#")) //$NON-NLS-1$
+                {
+                    // The marks live in the header. Past it there is nothing left to find, and
+                    // reading a megabyte of rows to learn that costs more than it tells.
+                    return false;
+                }
+            }
+            return false;
+        }
+        catch (IOException | RuntimeException cannotRead)
+        {
+            // Unreadable is not "ordinary". A file a crash left mid-publish reads like this, and it
+            // is the one that must not be removed.
+            Activator.logWarning("support snapshot " + file + " could not be read, so it is " //$NON-NLS-1$ //$NON-NLS-2$
+                + "treated as protected: " + cannotRead.getMessage()); //$NON-NLS-1$
+            return true;
+        }
+    }
+
+    /** The snapshots of this project that cleanup will not touch. */
+    public static List<Path> protectedIn(Path settings)
+    {
+        List<Path> held = new ArrayList<>();
+        for (Path file : list(settings))
+        {
+            if (isProtected(file))
+            {
+                held.add(file);
+            }
+        }
+        return held;
+    }
+
+    /**
+     * Takes the protection off one snapshot, so it becomes an ordinary one.
+     * <p>
+     * <b>Written aside and moved into place, and refused when the move cannot be atomic.</b> This
+     * rewrites the one file that can put the support model back. Publishing a NEW snapshot tolerates
+     * a non-atomic move - either the whole new file arrives or the old state stays, and refusing
+     * there would refuse every merge on such a volume. Here the trade is the other way round: a
+     * non-atomic replace that fails part-way destroys the only copy, and answering "unreadable
+     * counts as protected" does not bring the rows back.
+     * </p>
+     *
+     * @param file the snapshot to release.
+     * @return <code>null</code> when it is now ordinary, or the reason it is still protected
+     */
+    public static String clearProtection(Path file)
+    {
+        if (file == null || !Files.isRegularFile(file))
+        {
+            return "there is no snapshot at " + file; //$NON-NLS-1$
+        }
+        if (!isProtected(file))
+        {
+            return null;
+        }
+        Path staging = file.resolveSibling(file.getFileName() + ".writing"); //$NON-NLS-1$
+        try
+        {
+            List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+            List<String> without = new ArrayList<>(lines.size());
+            for (String line : lines)
+            {
+                if (!SupportSnapshot.PROTECTED.equals(line.trim()))
+                {
+                    without.add(line);
+                }
+            }
+            Files.write(staging, without, StandardCharsets.UTF_8);
+            try
+            {
+                Files.move(staging, file, StandardCopyOption.ATOMIC_MOVE);
+            }
+            catch (AtomicMoveNotSupportedException noAtomicMove)
+            {
+                Files.deleteIfExists(staging);
+                return "this volume does not promise an atomic replace, and replacing the only " //$NON-NLS-1$
+                    + "snapshot without one can destroy it. The snapshot stays protected; remove " //$NON-NLS-1$
+                    + "it by hand once the merge it belongs to has been dealt with."; //$NON-NLS-1$
+            }
+            return null;
+        }
+        catch (IOException | RuntimeException cannotRewrite)
+        {
+            try
+            {
+                Files.deleteIfExists(staging);
+            }
+            catch (IOException | RuntimeException leftBehind)
+            {
+                Activator.logWarning("a staging file was left at " + staging + ": " //$NON-NLS-1$ //$NON-NLS-2$
+                    + leftBehind.getMessage());
+            }
+            return "the snapshot could not be rewritten, so it stays protected: " //$NON-NLS-1$
+                + cannotRewrite.getMessage();
+        }
+    }
+
+    /**
+     * Removes the ordinary snapshots a project no longer needs.
+     * <p>
+     * Runs after a merge has settled and at start-up, never before a snapshot is taken: cleaning
+     * ahead of a merge would remove the previous way back for a merge that then refuses before
+     * writing anything, leaving the project with neither.
+     * </p>
+     *
+     * @param settings the project's settings directory.
+     * @param keep how many ordinary snapshots to leave, newest first.
+     * @return how many were removed
+     */
+    public static int prune(Path settings, int keep)
+    {
+        int removed = 0;
+        int seen = 0;
+        for (Path file : list(settings))
+        {
+            if (isProtected(file))
+            {
+                continue;
+            }
+            seen++;
+            if (seen <= keep)
+            {
+                continue;
+            }
+            try
+            {
+                Files.deleteIfExists(file);
+                removed++;
+            }
+            catch (IOException | RuntimeException staysOnDisk)
+            {
+                Activator.logWarning("support snapshot " + file + " could not be removed: " //$NON-NLS-1$ //$NON-NLS-2$
+                    + staysOnDisk.getMessage());
+            }
+        }
+        return removed;
+    }
+}

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/InfobaseAdminFacadeTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/InfobaseAdminFacadeTool.java
@@ -185,9 +185,15 @@ public class InfobaseAdminFacadeTool implements IMcpTool
             .stringProperty("syncOperation", //$NON-NLS-1$
                 "sync_control's OWN action - status / diagnose / diagnose_delta / suppress / " //$NON-NLS-1$
                     + "reseed_baseline / mark_synchronized / diagnose_stuck_locks / " //$NON-NLS-1$
-                    + "recover_stuck_merge (required when operation=sync_control). Kept " //$NON-NLS-1$
+                    + "recover_stuck_merge / list_support_snapshots / " //$NON-NLS-1$
+                    + "release_support_snapshot (required when operation=sync_control). Kept " //$NON-NLS-1$
                     + "separate from this facade's routing operation on purpose - sync_control " //$NON-NLS-1$
                     + "has its own operation concept.") //$NON-NLS-1$
+            .stringProperty("name", //$NON-NLS-1$
+                "sync_control syncOperation=release_support_snapshot: the snapshot's file name, as " //$NON-NLS-1$
+                    + "syncOperation=list_support_snapshots reports it. A protected snapshot is the " //$NON-NLS-1$
+                    + "only way back from a merge whose outcome is not known here; releasing it says " //$NON-NLS-1$
+                    + "that merge has been dealt with.") //$NON-NLS-1$
             .booleanProperty("enabled", //$NON-NLS-1$
                 "sync_control syncOperation=suppress: true = suppress synchronization for " //$NON-NLS-1$
                     + "the project (skip it on update), false = re-enable.") //$NON-NLS-1$
@@ -285,7 +291,8 @@ public class InfobaseAdminFacadeTool implements IMcpTool
         {
             return ToolResult.error("operation=sync_control requires syncOperation (status / " //$NON-NLS-1$
                 + "diagnose / diagnose_delta / suppress / reseed_baseline / " //$NON-NLS-1$
-                + "mark_synchronized / diagnose_stuck_locks / recover_stuck_merge) - " //$NON-NLS-1$
+                + "mark_synchronized / diagnose_stuck_locks / recover_stuck_merge / " //$NON-NLS-1$
+                + "list_support_snapshots / release_support_snapshot) - " //$NON-NLS-1$
                 + "sync_control has its own inner operation, kept separate from this facade's " //$NON-NLS-1$
                 + "routing operation.").toJson(); //$NON-NLS-1$
         }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
@@ -1039,6 +1039,24 @@ public class SyncControlTool implements IMcpTool
                 + "' has no location on disk, so it holds no snapshots.").toJson(); //$NON-NLS-1$
         }
         java.nio.file.Path file = settings.resolve(name);
+        // Named among the project's snapshots, not merely present in the directory. A typo naming
+        // some other file was answered as a successful release, and if that file happened to carry
+        // the protection comment it was rewritten - a settings file edited by a call that was
+        // supposed to touch one snapshot.
+        boolean listed = false;
+        for (java.nio.file.Path known : SupportSnapshotStore.list(settings))
+        {
+            if (known.getFileName().toString().equals(name))
+            {
+                listed = true;
+                break;
+            }
+        }
+        if (!listed)
+        {
+            return ToolResult.error("'" + name + "' is not one of this project's support " //$NON-NLS-1$ //$NON-NLS-2$
+                + "snapshots. Ask list_support_snapshots for the names.").toJson(); //$NON-NLS-1$
+        }
         String stillProtected = SupportSnapshotStore.clearProtection(file);
         if (stillProtected != null)
         {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
@@ -46,6 +46,7 @@ import ru.aiedt.mcp.server.wire.JsonUtils;
 import ru.aiedt.mcp.server.wire.ToolResult;
 import ru.aiedt.mcp.server.toolkit.IMcpTool;
 import ru.aiedt.mcp.server.support.ProjectResolver;
+import ru.aiedt.mcp.server.support.SupportSnapshotStore;
 import ru.aiedt.mcp.server.support.TextSuggest;
 
 /**
@@ -128,7 +129,12 @@ public class SyncControlTool implements IMcpTool
     {
         return SchemaComposer.object()
             .stringProperty("operation", "status | diagnose | diagnose_delta | suppress | reseed_baseline | " //$NON-NLS-1$ //$NON-NLS-2$
-                + "mark_synchronized | diagnose_stuck_locks | recover_stuck_merge (required)", true) //$NON-NLS-1$
+                + "mark_synchronized | diagnose_stuck_locks | recover_stuck_merge | " //$NON-NLS-1$
+                + "list_support_snapshots | release_support_snapshot (required)", true) //$NON-NLS-1$
+            .stringProperty("name", "For operation=release_support_snapshot: the snapshot's file " //$NON-NLS-1$ //$NON-NLS-2$
+                + "name, as list_support_snapshots reports it. A protected snapshot is the only way back " //$NON-NLS-1$
+                + "from a merge whose outcome is not known here; releasing it says that merge has been " //$NON-NLS-1$
+                + "dealt with, after which the limit may remove it.") //$NON-NLS-1$
             .stringProperty("projectName", "Project name (required). For 'only update the extension', " //$NON-NLS-1$ //$NON-NLS-2$
                 + "target the MAIN configuration project here.", true) //$NON-NLS-1$
             .booleanProperty("enabled", "For operation=suppress: true = suppress synchronization for the " //$NON-NLS-1$ //$NON-NLS-2$
@@ -195,10 +201,15 @@ public class SyncControlTool implements IMcpTool
                 return doDiagnoseStuckLocks(project);
             case "recover_stuck_merge": //$NON-NLS-1$
                 return doRecoverStuckMerge(project, params);
+            case "list_support_snapshots": //$NON-NLS-1$
+                return doListSupportSnapshots(project);
+            case "release_support_snapshot": //$NON-NLS-1$
+                return doReleaseSupportSnapshot(project, params);
             default:
                 return ToolResult.error("Unknown operation '" + operation //$NON-NLS-1$
                     + "'. Valid: status, diagnose, diagnose_delta, suppress, reseed_baseline, mark_synchronized, " //$NON-NLS-1$
-                    + "diagnose_stuck_locks, recover_stuck_merge.").toJson(); //$NON-NLS-1$
+                    + "diagnose_stuck_locks, recover_stuck_merge, list_support_snapshots, " //$NON-NLS-1$
+                    + "release_support_snapshot.").toJson(); //$NON-NLS-1$
         }
     }
 
@@ -950,6 +961,110 @@ public class SyncControlTool implements IMcpTool
      * flow-active flag is stuck (project != null). Only infobases touched this session appear -
      * inherent to an in-memory-only map.
      */
+    /**
+     * Lists the support-mode snapshots a project holds, saying which cleanup will not touch.
+     * <p>
+     * The names matter, not the count. A protected snapshot is released one at a time, by the file
+     * it belongs to, and after a restart there is nothing else to name it by.
+     * </p>
+     *
+     * @param project the project.
+     * @return the snapshots, newest first
+     */
+    private String doListSupportSnapshots(IProject project)
+    {
+        java.nio.file.Path settings = settingsOf(project);
+        if (settings == null)
+        {
+            return ToolResult.error("project '" + project.getName() //$NON-NLS-1$
+                + "' has no location on disk, so it holds no snapshots.").toJson(); //$NON-NLS-1$
+        }
+        java.util.List<java.util.Map<String, Object>> rows = new java.util.ArrayList<>();
+        for (java.nio.file.Path file : SupportSnapshotStore.list(settings))
+        {
+            java.util.Map<String, Object> row = new java.util.LinkedHashMap<>();
+            row.put("name", file.getFileName().toString()); //$NON-NLS-1$
+            row.put("protected", SupportSnapshotStore.isProtected(file)); //$NON-NLS-1$
+            try
+            {
+                row.put("bytes", java.nio.file.Files.size(file)); //$NON-NLS-1$
+            }
+            catch (java.io.IOException | RuntimeException sizeUnknown)
+            {
+                row.put("bytes", -1L); //$NON-NLS-1$
+            }
+            rows.add(row);
+        }
+        return ToolResult.success()
+            .put("operation", "list_support_snapshots") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("projectName", project.getName()) //$NON-NLS-1$
+            .put("kept", SupportSnapshotStore.KEPT) //$NON-NLS-1$
+            .put("snapshots", rows) //$NON-NLS-1$
+            .put("message", "A protected snapshot is the only way back from a merge whose outcome " //$NON-NLS-1$
+                + "is not known here, so cleanup leaves it. Release one with " //$NON-NLS-1$
+                + "operation=release_support_snapshot name=<file> once that merge has been dealt " //$NON-NLS-1$
+                + "with; it then becomes ordinary and the limit applies to it.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /**
+     * Takes the protection off one snapshot, after which the limit may remove it.
+     * <p>
+     * Deliberate and one at a time. The protection says nobody has yet established what a merge
+     * left behind, and only a person can establish it - so this is the one step the plugin will not
+     * take on its own.
+     * </p>
+     *
+     * @param project the project.
+     * @param params the call's arguments; {@code name} names the snapshot.
+     * @return what happened
+     */
+    private String doReleaseSupportSnapshot(IProject project, java.util.Map<String, String> params)
+    {
+        String name = JsonUtils.extractStringArgument(params, "name"); //$NON-NLS-1$
+        if (name == null || name.isEmpty())
+        {
+            return ToolResult.error("release_support_snapshot requires name - the snapshot's file " //$NON-NLS-1$
+                + "name, as list_support_snapshots reports it.").toJson(); //$NON-NLS-1$
+        }
+        if (name.contains("/") || name.contains("\\") || name.contains("..")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        {
+            return ToolResult.error("name is a file name inside the project's settings, not a " //$NON-NLS-1$
+                + "path.").toJson(); //$NON-NLS-1$
+        }
+        java.nio.file.Path settings = settingsOf(project);
+        if (settings == null)
+        {
+            return ToolResult.error("project '" + project.getName() //$NON-NLS-1$
+                + "' has no location on disk, so it holds no snapshots.").toJson(); //$NON-NLS-1$
+        }
+        java.nio.file.Path file = settings.resolve(name);
+        String stillProtected = SupportSnapshotStore.clearProtection(file);
+        if (stillProtected != null)
+        {
+            return ToolResult.error("'" + name + "' is still protected: " + stillProtected).toJson(); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+        int removed = SupportSnapshotStore.prune(settings, SupportSnapshotStore.KEPT);
+        return ToolResult.success()
+            .put("operation", "release_support_snapshot") //$NON-NLS-1$ //$NON-NLS-2$
+            .put("projectName", project.getName()) //$NON-NLS-1$
+            .put("name", name) //$NON-NLS-1$
+            .put("removedByLimit", removed) //$NON-NLS-1$
+            .put("message", "'" + name + "' is an ordinary snapshot now, and the limit of " //$NON-NLS-1$ //$NON-NLS-2$
+                + SupportSnapshotStore.KEPT + " applies to it.") //$NON-NLS-1$
+            .toJson();
+    }
+
+    /** Where a project keeps its settings, or <code>null</code> when it has no location. */
+    private static java.nio.file.Path settingsOf(IProject project)
+    {
+        if (project == null || project.getLocation() == null)
+        {
+            return null;
+        }
+        return project.getLocation().toFile().toPath().resolve(".settings"); //$NON-NLS-1$
+    }
+
     private String doDiagnoseStuckLocks(IProject project)
     {
         try

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ThreeWayComparisonTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ThreeWayComparisonTool.java
@@ -588,6 +588,11 @@ public class ThreeWayComparisonTool
             .put("supportSnapshotFile", outcome.supportSnapshotFile) //$NON-NLS-1$
             .put("supportSnapshotKeptBecause", outcome.supportSnapshotKeptBecause) //$NON-NLS-1$
             .put("supportSnapshotNote", outcome.supportSnapshotNote) //$NON-NLS-1$
+            // What the limit took, and what it left for a person to release. Held without
+            // being named is not actionable: releasing one needs the file it belongs to,
+            // and after a restart there is nothing else to name it by.
+            .put("supportSnapshotsRemoved", outcome.supportSnapshotsRemoved) //$NON-NLS-1$
+            .put("supportSnapshotsHeld", outcome.supportSnapshotsHeld) //$NON-NLS-1$
             // Said out loud, because it is the one thing a merge changes that lives outside both
             // the object list and the support snapshot - and restoring the source tree does not
             // put it back. Measured: a merge that took a delivery built for 8.3 moved the project

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ASnapshotSurvivesWhatCleanupForgetsTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ASnapshotSurvivesWhatCleanupForgetsTest.java
@@ -1,0 +1,189 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Which support snapshots a project keeps, and which it may remove.
+ * <p>
+ * Every successful merge leaves one, around a megabyte and a half on a configuration of nine
+ * thousand objects, and nothing removed them: five were lying in one project before an experiment
+ * on 25.08. They are not litter - a snapshot is the only way to put the support model back - so the
+ * question is which one may go, not how to delete them.
+ * </p>
+ */
+public class ASnapshotSurvivesWhatCleanupForgetsTest
+{
+    /**
+     * Its own directory rather than a JUnit rule: the test fragment imports org.junit,
+     * org.junit.runner and org.junit.runners, and a package it does not import does not
+     * resolve in the runtime the suite actually runs in.
+     */
+    private Path settings;
+
+    @Before
+    public void makeSettingsDirectory() throws IOException
+    {
+        settings = Files.createTempDirectory("aiedt-snapshot-test");
+    }
+
+    @After
+    public void removeSettingsDirectory() throws IOException
+    {
+        if (settings == null)
+        {
+            return;
+        }
+        try (java.util.stream.Stream<Path> entries = Files.walk(settings))
+        {
+            List<Path> deepestFirst = new java.util.ArrayList<>(
+                entries.collect(java.util.stream.Collectors.toList()));
+            java.util.Collections.reverse(deepestFirst);
+            for (Path entry : deepestFirst)
+            {
+                Files.deleteIfExists(entry);
+            }
+        }
+    }
+
+    private Path snapshot(String stamp, boolean marked) throws IOException
+    {
+        Path file = settings.resolve("aiedt-support-snapshot-" + stamp + ".tsv");
+        List<String> lines = marked
+            ? Arrays.asList(SupportSnapshot.HEADER, SupportSnapshot.PROTECTED, "# project\tP",
+                "a\tb\tCHANGES_ALLOWED\tName")
+            : Arrays.asList(SupportSnapshot.HEADER, "# project\tP", "a\tb\tCHANGES_ALLOWED\tName");
+        Files.write(file, lines, StandardCharsets.UTF_8);
+        return file;
+    }
+
+    @Test
+    public void aMarkedSnapshotIsProtectedAndAPlainOneIsNot() throws IOException
+    {
+        assertTrue(SupportSnapshotStore.isProtected(snapshot("20260101-000001-aaaaaaaa", true)));
+        assertFalse(SupportSnapshotStore.isProtected(snapshot("20260101-000002-bbbbbbbb", false)));
+    }
+
+    /**
+     * A file a crash left mid-publish reads like this. Calling it ordinary would delete exactly the
+     * snapshot that matters most, so the unknown answer is the safe one.
+     */
+    @Test
+    public void whatCannotBeReadCountsAsProtected() throws IOException
+    {
+        Path torn = settings.resolve("aiedt-support-snapshot-20260101-000003-cccccccc.tsv");
+        Files.write(torn, new byte[] { (byte)0xff, (byte)0xfe, (byte)0xff });
+        assertTrue(SupportSnapshotStore.isProtected(torn));
+    }
+
+    @Test
+    public void theLimitLeavesTheNewestOrdinaryOnes() throws IOException
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            snapshot("2026010" + i + "-000000-0000000" + i, false);
+        }
+        assertEquals(2, SupportSnapshotStore.prune(settings, 3));
+        assertEquals(3, SupportSnapshotStore.list(settings).size());
+        assertTrue("the newest ordinary snapshot stays",
+            Files.exists(settings
+                .resolve("aiedt-support-snapshot-20260105-000000-00000005.tsv")));
+    }
+
+    /** The whole point: a protected snapshot is not counted and is never the one removed. */
+    @Test
+    public void aProtectedSnapshotIsNeitherCountedNorRemoved() throws IOException
+    {
+        Path held = snapshot("20260101-000000-00000001", true);
+        for (int i = 2; i <= 5; i++)
+        {
+            snapshot("2026010" + i + "-000000-0000000" + i, false);
+        }
+        SupportSnapshotStore.prune(settings, 3);
+        assertTrue("the oldest file of all is the one that had to survive", Files.exists(held));
+        assertEquals("three ordinary ones plus the protected one",
+            4, SupportSnapshotStore.list(settings).size());
+    }
+
+    /**
+     * More protected snapshots than the limit does not block anything and does not remove them:
+     * refusing new merges would let one indeterminate merge stop all further work, which is worse
+     * than the room they take.
+     */
+    @Test
+    public void moreProtectedThanTheLimitIsAllowed() throws IOException
+    {
+        for (int i = 1; i <= 5; i++)
+        {
+            snapshot("2026010" + i + "-000000-0000000" + i, true);
+        }
+        assertEquals(0, SupportSnapshotStore.prune(settings, 3));
+        assertEquals(5, SupportSnapshotStore.protectedIn(settings).size());
+    }
+
+    @Test
+    public void releasingASnapshotMakesItOrdinary() throws IOException
+    {
+        Path held = snapshot("20260101-000000-00000001", true);
+        assertNull(SupportSnapshotStore.clearProtection(held));
+        assertFalse(SupportSnapshotStore.isProtected(held));
+        assertTrue("the rows have to survive the rewrite",
+            Files.readAllLines(held, StandardCharsets.UTF_8).contains("a\tb\tCHANGES_ALLOWED\tName"));
+    }
+
+    /** Releasing what is already ordinary is not an error: the caller asked for a state it is in. */
+    @Test
+    public void releasingTwiceIsNotAnError() throws IOException
+    {
+        Path held = snapshot("20260101-000000-00000001", true);
+        assertNull(SupportSnapshotStore.clearProtection(held));
+        assertNull(SupportSnapshotStore.clearProtection(held));
+    }
+
+    @Test
+    public void releasingWhatIsNotThereSaysSo()
+    {
+        assertNotNull(SupportSnapshotStore.clearProtection(
+            settings.resolve("aiedt-support-snapshot-nope.tsv")));
+    }
+
+    /** Only snapshots are listed; whatever else the settings directory holds is not ours. */
+    @Test
+    public void onlySnapshotsAreListed() throws IOException
+    {
+        snapshot("20260101-000000-00000001", false);
+        Files.write(settings.resolve("aiedt-markers.yaml"),
+            Arrays.asList("markers:"), StandardCharsets.UTF_8);
+        Files.write(settings.resolve("aiedt-clusters.yaml"),
+            Arrays.asList("clusters:"), StandardCharsets.UTF_8);
+        assertEquals(1, SupportSnapshotStore.list(settings).size());
+    }
+
+    @Test
+    public void nothingThereIsNotAFailure()
+    {
+        assertTrue(SupportSnapshotStore.list(settings).isEmpty());
+        assertEquals(0, SupportSnapshotStore.prune(settings, 3));
+        assertTrue(SupportSnapshotStore.protectedIn(settings).isEmpty());
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ASnapshotSurvivesWhatCleanupForgetsTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ASnapshotSurvivesWhatCleanupForgetsTest.java
@@ -179,6 +179,40 @@ public class ASnapshotSurvivesWhatCleanupForgetsTest
         assertEquals(1, SupportSnapshotStore.list(settings).size());
     }
 
+    /**
+     * Restoring support modes writes its undo record beside the snapshot it restored from, named
+     * after it. That record is the only way to reverse a restore, and the file pattern alone counts
+     * it as an ordinary snapshot - so cleanup would delete exactly that.
+     */
+    @Test
+    public void anUndoRecordIsNotASnapshot() throws IOException
+    {
+        Path snapshotFile = snapshot("20260101-000000-00000001", false);
+        String undoName = snapshotFile.getFileName() + ".before-restore.tsv";
+        Path undo = settings.resolve(undoName);
+        Files.write(undo, Arrays.asList(SupportSnapshot.HEADER), StandardCharsets.UTF_8);
+        Path secondUndo = settings.resolve(snapshotFile.getFileName() + ".before-restore.2.tsv");
+        Files.write(secondUndo, Arrays.asList(SupportSnapshot.HEADER), StandardCharsets.UTF_8);
+
+        assertEquals("only the snapshot itself is ours", 1, SupportSnapshotStore.list(settings).size());
+        SupportSnapshotStore.prune(settings, 0);
+        assertTrue("the undo record survives cleanup", Files.exists(undo));
+        assertTrue("and so does a numbered one", Files.exists(secondUndo));
+    }
+
+    @Test
+    public void whatIsNamedLikeASnapshotButIsNotIsLeftAlone()
+    {
+        assertTrue(SupportSnapshotStore.isSnapshotName("aiedt-support-snapshot-20260101-000000-a1.tsv"));
+        assertFalse(SupportSnapshotStore
+            .isSnapshotName("aiedt-support-snapshot-20260101-000000-a1.tsv.before-restore.tsv"));
+        assertFalse(SupportSnapshotStore
+            .isSnapshotName("aiedt-support-snapshot-20260101-000000-a1.tsv.writing"));
+        assertFalse(SupportSnapshotStore.isSnapshotName("aiedt-support-snapshot-.tsv.other.tsv"));
+        assertFalse(SupportSnapshotStore.isSnapshotName("aiedt-markers.yaml"));
+        assertFalse(SupportSnapshotStore.isSnapshotName(null));
+    }
+
     @Test
     public void nothingThereIsNotAFailure()
     {


### PR DESCRIPTION
Every successful merge left a support-mode snapshot in the project's settings - around a megabyte and a half on a configuration of nine thousand objects - and nothing ever removed one. Five were lying in a single project before an experiment on 25.08.

They are not litter. A snapshot is the only way to put the support model back, so the question is which one may go, not how to delete them.

**Published already protected.** The mark is written into the file before the atomic move, so there is no instant at which a snapshot exists without it. Marking after the move would leave a window in which a crash produces a snapshot cleanup takes for an ordinary one. Protection comes off only when the merge finishes, so any crash leaves it on.

**Releasing goes through a staging file** and refuses when the move cannot be atomic. Publishing tolerates a non-atomic move - either the whole new file arrives or the old state stays. Replacing the only copy does not: a failure part-way destroys it, and calling an unreadable file protected does not bring the rows back.

**An unreadable snapshot counts as protected.** That is what a crash mid-publish leaves, and it is the one that must not go.

**The limit is three ordinary snapshots per project.** Protected ones are not counted and are never removed automatically. More protected snapshots than the limit blocks nothing: refusing new merges would let one indeterminate merge stop all further work.

**Cleanup runs when a merge settles and at start-up**, never before a snapshot is taken - that would remove the previous way back for a merge that then refuses before writing anything. The undo record a restore writes beside a snapshot is excluded by name: it is the only way to reverse a restore.

`sync_control` gains `list_support_snapshots` and `release_support_snapshot`, addressed by file name - after a restart a count is nothing to act on. Both are declared on `infobase_admin` too.

Build: 2028 tests, no failures. All eight gates pass.

Not yet verified on a running stand - the live check is outstanding.
