### PR TITLE
Refuse a default form the object never declares

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 62 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **379** | across 211 test classes |
+| **total** | **379** | across 212 test classes |
 
 ## untested (0)
 
@@ -508,7 +508,7 @@ closes.
 | 9-16 | 47 |
 | 17+ | 15 |
 
-2028 test methods across 211 test classes; 113 classes have a test of their own, median 9 methods each.
+2036 test methods across 212 test classes; 113 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 113 of 379 classes have one: 90 are covered by the registry-wide contract sweep and 62 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ValidateForExportTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ValidateForExportTool.java
@@ -664,6 +664,14 @@ public class ValidateForExportTool implements IMcpTool
             && content != null && !content.contains("<containedObjects"); //$NON-NLS-1$
     }
 
+    /** {@code <defaultObjectForm>Type.Name.Form.X</defaultObjectForm>} and its siblings. */
+    private static final Pattern MDO_DEFAULT_FORM =
+        Pattern.compile("<(default[A-Za-z]*Form)>([^<]+)</\\1>"); //$NON-NLS-1$
+
+    /** The {@code <name>} inside a {@code <forms>} block - what the object actually declares. */
+    private static final Pattern MDO_FORM_NAME =
+        Pattern.compile("<forms\\b[^>]*>\\s*<name>([^<]+)</name>"); //$NON-NLS-1$
+
     private void scanMdo(String content, String relPath, String fqn, String checkFilterLower,
         List<Map<String, Object>> findings, IFile file)
     {
@@ -706,6 +714,22 @@ public class ValidateForExportTool implements IMcpTool
                 + "on update_database with \"Отсутствует внутренняя информация (узел InternalInfo)\" " //$NON-NLS-1$
                 + "and names a /Configuration.xml this project does not have. A configuration " //$NON-NLS-1$
                 + "carries seven, one per platform class id, each with an objectId of its own."); //$NON-NLS-1$
+        }
+
+        // A default form that names a form the object does not declare. Measured 31.08: a
+        // document kept <defaultObjectForm> after its whole <forms> block was gone - EDT had
+        // rewritten the .mdo from its own model after being killed - and every check passed.
+        // validate_for_export answered no findings on 254 files, revalidate and get_project_errors
+        // were clean, and update_database died in the platform with
+        // "Неизвестный объект метаданных - Document.X.Form.ФормаДокумента". This is the class the
+        // whole tool exists for: valid in EDT, refused by the infobase.
+        for (String missing : danglingDefaultForms(content, fqn))
+        {
+            add(findings, checkFilterLower, relPath, fqn,
+                "mdo-dangling-default-form", "ERROR", lineOf(content, content.indexOf(missing)), //$NON-NLS-1$ //$NON-NLS-2$
+                "a default form names '" + missing + "', which this object does not declare in " //$NON-NLS-1$ //$NON-NLS-2$
+                + "<forms> - the platform refuses the update with \"Неизвестный объект " //$NON-NLS-1$
+                + "метаданных\". Declare the form, or drop the reference to it."); //$NON-NLS-1$
         }
 
         Matcher m = MDO_EMPTY_NUMBER_FILLVALUE.matcher(content);
@@ -760,6 +784,54 @@ public class ValidateForExportTool implements IMcpTool
     }
 
     // ---- .dcs -----------------------------------------------------------
+
+
+    /**
+     * Which forms a default-form reference names that the object never declares.
+     * <p>
+     * Only a reference to this object's OWN form is judged. A reference reaching another object -
+     * a common form, a form of a different type - resolves elsewhere and is not this file's to
+     * answer for; treating it as missing here would refuse a configuration that loads.
+     * </p>
+     *
+     * @param content the .mdo text.
+     * @param fqn the object's own FQN, as the scan resolved it.
+     * @return the form names referenced and not declared, in the order they appear
+     */
+    static java.util.List<String> danglingDefaultForms(String content, String fqn)
+    {
+        java.util.List<String> dangling = new java.util.ArrayList<>();
+        if (content == null || fqn == null || fqn.isEmpty())
+        {
+            return dangling;
+        }
+        java.util.Set<String> declared = new java.util.LinkedHashSet<>();
+        Matcher declaredForms = MDO_FORM_NAME.matcher(content);
+        while (declaredForms.find())
+        {
+            declared.add(declaredForms.group(1).trim());
+        }
+        String ownPrefix = fqn + ".Form.";
+        Matcher references = MDO_DEFAULT_FORM.matcher(content);
+        while (references.find())
+        {
+            String target = references.group(2).trim();
+            if (!target.startsWith(ownPrefix))
+            {
+                continue;
+            }
+            String formName = target.substring(ownPrefix.length());
+            if (formName.isEmpty() || formName.indexOf('.') >= 0)
+            {
+                continue;
+            }
+            if (!declared.contains(formName) && !dangling.contains(formName))
+            {
+                dangling.add(formName);
+            }
+        }
+        return dangling;
+    }
 
     private void scanDcs(String content, String relPath, String fqn, String checkFilterLower,
         List<Map<String, Object>> findings)

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ADefaultFormMustBeDeclaredTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ADefaultFormMustBeDeclaredTest.java
@@ -1,0 +1,120 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * A default form that names a form the object never declares.
+ * <p>
+ * Measured 31.08: a document kept its {@code defaultObjectForm} after the whole {@code forms} block
+ * was gone - EDT had rewritten the .mdo from its own model after the process was killed - and every
+ * check passed. The export validator answered no findings on 254 files, revalidation and the
+ * project's own errors were clean, and the infobase update died in the platform with "Неизвестный
+ * объект метаданных". This is the class of fault the validator exists for: valid in EDT, refused by
+ * the infobase.
+ * </p>
+ */
+public class ADefaultFormMustBeDeclaredTest
+{
+    private static String mdo(String... lines)
+    {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<mdclass:Catalog>\n"
+            + String.join("\n", lines) + "\n</mdclass:Catalog>\n";
+    }
+
+    private static String declares(String formName)
+    {
+        return "  <forms uuid=\"93ad0ecb-5275-45b2-afed-4d4abf6b36f2\">\n    <name>" + formName
+            + "</name>\n  </forms>";
+    }
+
+    @Test
+    public void aReferenceWithNoDeclarationIsFound()
+    {
+        List<String> dangling = ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Товары.Form.ФормаЭлемента</defaultObjectForm>"),
+            "Catalog.Товары");
+        assertEquals(Arrays.asList("ФормаЭлемента"), dangling);
+    }
+
+    @Test
+    public void aDeclaredFormIsNotAFinding()
+    {
+        assertTrue(ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Товары.Form.ФормаЭлемента</defaultObjectForm>",
+                declares("ФормаЭлемента")),
+            "Catalog.Товары").isEmpty());
+    }
+
+    /** Every default-form property is judged, not only the object one. */
+    @Test
+    public void everyKindOfDefaultFormIsJudged()
+    {
+        List<String> dangling = ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Товары.Form.Ф1</defaultObjectForm>",
+                "  <defaultListForm>Catalog.Товары.Form.Ф2</defaultListForm>",
+                "  <defaultChoiceForm>Catalog.Товары.Form.Ф3</defaultChoiceForm>",
+                "  <defaultFolderForm>Catalog.Товары.Form.Ф4</defaultFolderForm>",
+                declares("Ф2")),
+            "Catalog.Товары");
+        assertEquals(Arrays.asList("Ф1", "Ф3", "Ф4"), dangling);
+    }
+
+    /**
+     * A reference reaching another object resolves elsewhere and is not this file's to answer for.
+     * Judging it here would refuse a configuration that loads.
+     */
+    @Test
+    public void aFormOfAnotherObjectIsNotJudged()
+    {
+        assertTrue(ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Другой.Form.ФормаЭлемента</defaultObjectForm>"),
+            "Catalog.Товары").isEmpty());
+    }
+
+    /** A common form is named without a Form segment of its own, and belongs to no object here. */
+    @Test
+    public void aCommonFormIsNotJudged()
+    {
+        assertTrue(ValidateForExportTool.danglingDefaultForms(
+            mdo("  <auxiliaryReportForm>CommonForm.ОбщаяФорма</auxiliaryReportForm>"),
+            "Catalog.Товары").isEmpty());
+    }
+
+    /** The same missing form named by two properties is one finding, not two. */
+    @Test
+    public void oneMissingFormIsReportedOnce()
+    {
+        assertEquals(Arrays.asList("Ф1"), ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Товары.Form.Ф1</defaultObjectForm>",
+                "  <defaultChoiceForm>Catalog.Товары.Form.Ф1</defaultChoiceForm>"),
+            "Catalog.Товары"));
+    }
+
+    @Test
+    public void anObjectWithNoDefaultFormIsNotAFinding()
+    {
+        assertTrue(ValidateForExportTool.danglingDefaultForms(
+            mdo("  <name>Товары</name>", declares("ФормаЭлемента")), "Catalog.Товары").isEmpty());
+    }
+
+    @Test
+    public void nothingToReadIsNotAFinding()
+    {
+        assertTrue(ValidateForExportTool.danglingDefaultForms(null, "Catalog.Товары").isEmpty());
+        assertTrue(ValidateForExportTool.danglingDefaultForms("", "Catalog.Товары").isEmpty());
+        assertTrue(ValidateForExportTool.danglingDefaultForms(
+            mdo("  <defaultObjectForm>Catalog.Товары.Form.Ф1</defaultObjectForm>"), null).isEmpty());
+    }
+}


### PR DESCRIPTION
Measured 31.08: a document kept its `defaultObjectForm` after the whole `<forms>` block was gone - EDT had rewritten the .mdo from its own model after the process was killed - and every check passed. `validate_for_export` answered no findings on 254 files, revalidation and the project's own errors were clean, and `update_database` died in the platform with «Неизвестный объект метаданных - Document.X.Form.ФормаДокумента».

This is the class of fault the export validator exists for: valid in EDT, refused by the infobase.

`mdo-dangling-default-form` reports a default form naming a form the object does not declare. Every `default*Form` property is read, not only the object one.

Only a reference to the object's **own** form is judged. One reaching another object - a common form, a form of a different type - resolves elsewhere and is not this file's to answer for; judging it here would refuse a configuration that loads.

**False positives measured, not assumed:** 10395 `.mdo` files across the workspace, 1047 of them carrying a default-form reference, **zero findings**. Positive control on the same corpus: strip the `<forms>` block from one of those objects and the rule names the form.

The check is not yet called before an infobase update - it answers when `validate_for_export` is asked. Wiring it into the update path closes the route by which a related defect is still being reproduced, so it waits for that measurement.

Build: 2036 tests, no failures. All eight gates pass.
