### PR TITLE
Photograph a form in a running 1C

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,9 +114,9 @@ Supporting scripts:
 - **McpToolCatalog** (`toolkit/McpToolCatalog.java`) - thread-safe registry singleton. Registration
   and enablement are separate questions: a tool is registered at startup and may still be switched
   off by preferences. Each tool owns a capability id; a duplicate capability is a programming error.
-- **Tool implementations** live in `toolkit/ops/`. There are 126 callable tool names (the count
+- **Tool implementations** live in `toolkit/ops/`. There are 129 callable tool names (the count
   `scripts/check-tool-catalog.py` reconciles between `ToolCategory` and the catalog). Under the
-  default Canonical preset `tools/list` advertises 44 of them: the facades plus the tools no facade
+  default Canonical preset `tools/list` advertises 46 of them: the facades plus the tools no facade
   covers. The rest stay hidden but callable as backward-compatible aliases. These three numbers go
   stale on every tool added - read them off the script and a live `tools/list` rather than trusting
   what is written here.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2317 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
+2320 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 58 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,18 +6,18 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 115 | a test class named after it |
-| exercised | 73 | reached by some other test |
+| exercised | 74 | reached by some other test |
 | tool-sweep | 89 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 50 | needs a display or an extension point |
-| workspace-bound | 58 | drives a live EDT project or debug session |
+| workspace-bound | 57 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **385** | across 240 test classes |
+| **total** | **385** | across 241 test classes |
 
 ## untested (0)
 
 _none_
 
-## workspace-bound (58)
+## workspace-bound (57)
 
 **folders**
 - IClusterChangeObserver
@@ -68,7 +68,6 @@ _none_
 - DebugValueSerializer
 - ExternalProjectResolver
 - FileMarkers
-- InfobaseAddress
 - InfobaseIdentity
 - LaunchConfigAccess
 - MetadataDiffEngine
@@ -262,7 +261,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (73)
+## exercised (74)
 
 **(root)**
 - Activator
@@ -307,6 +306,7 @@ _none_
 - DcsExtensionExportHelper
 - ErrorTags
 - ExportedFiles
+- InfobaseAddress
 - JUnitRunOutcome
 - MetadataGuards
 - OffScreenTextViewer
@@ -516,9 +516,9 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2328 test methods across 240 test classes; 115 classes have a test of their own, median 9 methods each.
+2331 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 58 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 58 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **385** | across 239 test classes |
+| **total** | **385** | across 240 test classes |
 
 ## untested (0)
 
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2320 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
+2328 test methods across 240 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 58 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -9,15 +9,15 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | exercised | 73 | reached by some other test |
 | tool-sweep | 89 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 50 | needs a display or an extension point |
-| workspace-bound | 57 | drives a live EDT project or debug session |
+| workspace-bound | 58 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **384** | across 239 test classes |
+| **total** | **385** | across 239 test classes |
 
 ## untested (0)
 
 _none_
 
-## workspace-bound (57)
+## workspace-bound (58)
 
 **folders**
 - IClusterChangeObserver
@@ -68,6 +68,7 @@ _none_
 - DebugValueSerializer
 - ExternalProjectResolver
 - FileMarkers
+- InfobaseAddress
 - InfobaseIdentity
 - LaunchConfigAccess
 - MetadataDiffEngine
@@ -517,7 +518,7 @@ closes.
 
 2315 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 384 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 58 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2334 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
+2335 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2331 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
+2334 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -515,7 +515,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2312 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
+2315 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 384 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2315 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
+2317 test methods across 239 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 58 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 115 | a test class named after it |
-| exercised | 74 | reached by some other test |
+| exercised | 75 | reached by some other test |
 | tool-sweep | 89 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 50 | needs a display or an extension point |
 | workspace-bound | 57 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **385** | across 241 test classes |
+| **total** | **386** | across 242 test classes |
 
 ## untested (0)
 
@@ -261,7 +261,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (74)
+## exercised (75)
 
 **(root)**
 - Activator
@@ -288,6 +288,7 @@ _none_
 - PrefKeys
 
 **support**
+- AllureResultReader
 - BmComparisonHelper
 - BmConfigurationProjectHelper
 - BmDcsHelper
@@ -516,9 +517,9 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2334 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
+2337 test methods across 242 test classes; 115 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 386 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -516,7 +516,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2335 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
+2334 test methods across 241 test classes; 115 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 115 of 385 classes have one: 89 are covered by the registry-wide contract sweep and 57 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/AllureResultReader.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/AllureResultReader.java
@@ -1,0 +1,153 @@
+/**
+ * AI-EDT - 1C AI tools for EDT
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Locale;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * What a Vanessa run left behind, read from the files it actually writes.
+ * <p>
+ * Vanessa has no JUnit parameters of its own. Asked for a machine readable result through the
+ * documented pair - {@code ДелатьОтчетВФорматеАллюр} and {@code КаталогOutputAllureБазовый} - it
+ * writes one {@code <uuid>-result.json} per scenario, and names the files itself. A caller looking
+ * for a single file of its own naming finds nothing and reads the run as one that produced no
+ * result.
+ * </p>
+ */
+public final class AllureResultReader
+{
+    /** What Vanessa calls a scenario that failed on an assertion. */
+    private static final String FAILED = "failed"; //$NON-NLS-1$
+
+    /** What Vanessa calls a scenario that stopped on an error. */
+    private static final String BROKEN = "broken"; //$NON-NLS-1$
+
+    /** What Vanessa calls a scenario it did not run. */
+    private static final String SKIPPED = "skipped"; //$NON-NLS-1$
+
+    /** The tail every result file carries. */
+    static final String RESULT_SUFFIX = "-result.json"; //$NON-NLS-1$
+
+    private AllureResultReader()
+    {
+        // Read through the static entry points.
+    }
+
+    /**
+     * The result files of a run, newest last.
+     *
+     * @param dir the run directory; may be <code>null</code>.
+     * @return the files, empty when the directory holds none
+     */
+    public static File[] resultsIn(File dir)
+    {
+        File[] found = dir == null ? null
+            : dir.listFiles((d, name) -> name.toLowerCase(Locale.ROOT).endsWith(RESULT_SUFFIX));
+        if (found == null)
+        {
+            return new File[0];
+        }
+        Arrays.sort(found, Comparator.comparingLong(File::lastModified));
+        return found;
+    }
+
+    /**
+     * Reads every scenario of a run into the shape the rest of this plugin reports on.
+     *
+     * @param dir the run directory.
+     * @return the outcome; a run with no result files reads as one with no tests
+     * @throws IOException if a file is there and cannot be read
+     */
+    public static JUnitRunOutcome parse(File dir) throws IOException
+    {
+        JUnitRunOutcome outcome = new JUnitRunOutcome();
+        int total = 0;
+        int failures = 0;
+        int errors = 0;
+        int skipped = 0;
+        for (File file : resultsIn(dir))
+        {
+            JsonObject one = read(file);
+            if (one == null)
+            {
+                continue;
+            }
+            total++;
+            String name = text(one, "name"); //$NON-NLS-1$
+            String status = text(one, "status"); //$NON-NLS-1$
+            JsonObject details = one.has("statusDetails") && one.get("statusDetails").isJsonObject() //$NON-NLS-1$ //$NON-NLS-2$
+                ? one.getAsJsonObject("statusDetails") : null; //$NON-NLS-1$
+            String message = details == null ? null : text(details, "message"); //$NON-NLS-1$
+            String trace = details == null ? null : text(details, "trace"); //$NON-NLS-1$
+            JUnitRunOutcome.TestCase testCase = new JUnitRunOutcome.TestCase(name, message, trace);
+            if (FAILED.equalsIgnoreCase(status))
+            {
+                failures++;
+                outcome.addFailure(testCase);
+            }
+            else if (BROKEN.equalsIgnoreCase(status))
+            {
+                errors++;
+                outcome.addError(testCase);
+            }
+            else if (SKIPPED.equalsIgnoreCase(status))
+            {
+                skipped++;
+                outcome.addSkipped(testCase);
+            }
+        }
+        outcome.addToTotals(total, failures, errors, skipped);
+        return outcome;
+    }
+
+    /**
+     * One result file as an object.
+     *
+     * @param file the file.
+     * @return its content, or <code>null</code> when it is not an object
+     * @throws IOException if it cannot be read
+     */
+    private static JsonObject read(File file) throws IOException
+    {
+        try (Reader reader =
+            new InputStreamReader(Files.newInputStream(file.toPath()), StandardCharsets.UTF_8))
+        {
+            JsonElement parsed = JsonParser.parseReader(reader);
+            return parsed != null && parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+        }
+        catch (RuntimeException malformed)
+        {
+            throw new IOException("the result file is not readable json: " //$NON-NLS-1$
+                + file.getAbsolutePath(), malformed);
+        }
+    }
+
+    /**
+     * A string member, or <code>null</code>.
+     *
+     * @param owner the object.
+     * @param member the member name.
+     * @return the text, or <code>null</code> when absent or not a string
+     */
+    private static String text(JsonObject owner, String member)
+    {
+        JsonElement value = owner.get(member);
+        return value != null && value.isJsonPrimitive() ? value.getAsString() : null;
+    }
+}

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
@@ -6,7 +6,7 @@
 
 package ru.aiedt.mcp.server.support;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
 
@@ -22,10 +22,10 @@ import ru.aiedt.mcp.server.Activator;
 /**
  * Where a project's infobase is, in the words a 1C client understands.
  * <p>
- * A caller that has EDT open already told it which infobase the project belongs to - it is what
- * update_database writes into and what start_client launches. Asking that caller to type a
- * connection string as well makes them repeat what the environment knows, and a typed string can
- * name a different infobase than the one the project is bound to.
+ * A caller with EDT open has already told it which infobase the project belongs to - the one
+ * update_database writes into and start_client launches. Asking that caller to type a connection
+ * string as well makes them repeat what the environment holds, and a typed string can name a
+ * different infobase than the project is bound to.
  * </p>
  */
 public final class InfobaseAddress
@@ -33,45 +33,68 @@ public final class InfobaseAddress
     private InfobaseAddress() {}
 
     /**
-     * The connection string of a project's infobase.
+     * A project's infobase, named two ways at once.
+     *
+     * @param connectionString what a 1C client is started with, or <code>null</code>.
+     * @param name what the infobase is called in EDT, or <code>null</code>.
+     */
+    public record Address(String connectionString, String name)
+    {
+        /** @return whether an address was found */
+        public boolean found()
+        {
+            return connectionString != null && !connectionString.isEmpty();
+        }
+    }
+
+    /** Nothing found, so a caller reading this cannot mistake it for an address. */
+    private static final Address NOWHERE = new Address(null, null);
+
+    /**
+     * The infobase a project is bound to.
+     * <p>
+     * Resolved once, so the connection string and the name always describe the same infobase: two
+     * independent lookups can disagree if the application list changes between them, and an answer
+     * naming one infobase while the run went to another is worse than an answer naming none.
+     * </p>
      *
      * @param project the project, possibly <code>null</code>.
-     * @return the connection string for a file infobase, or <code>null</code> when the project has
-     *         no infobase application, when EDT is not up, or when the infobase is not a file one -
-     *         a server infobase carries credentials this cannot supply
+     * @return the address; {@link Address#found()} is false when the project has no infobase
+     *         application, when EDT is not up, or when the infobase is a server one - that carries
+     *         credentials this cannot supply, so the caller has to name it
      */
-    public static String ofProject(IProject project)
+    public static Address ofProject(IProject project)
     {
         InfobaseReference infobase = infobaseOf(project);
         if (infobase == null)
         {
-            return null;
+            return NOWHERE;
         }
         IConnectionString connection = infobase.getConnectionString();
         if (!(connection instanceof FileConnectionString))
         {
-            return null;
+            return NOWHERE;
         }
         String file = ((FileConnectionString)connection).getFile();
         if (file == null || file.trim().isEmpty())
         {
-            return null;
+            return NOWHERE;
         }
-        return "File=\"" + file.trim() + "\";"; //$NON-NLS-1$ //$NON-NLS-2$
+        return new Address("File=\"" + file.trim() + "\";", infobase.getName()); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**
-     * The name of a project's infobase, for an answer that says which one was used.
+     * The infobase of a project's default application, or of its parent's.
+     * <p>
+     * The default one, not the first of the list: a project may have several, and the first is not
+     * the one the rest of this plugin works with. An extension project usually has none of its own
+     * and belongs to the configuration above it, which is the route the event log and the database
+     * updater already take.
+     * </p>
      *
-     * @param project the project, possibly <code>null</code>.
-     * @return the name, or <code>null</code>
+     * @param project the project.
+     * @return the infobase, or <code>null</code>
      */
-    public static String nameOfProjectInfobase(IProject project)
-    {
-        InfobaseReference infobase = infobaseOf(project);
-        return infobase == null ? null : infobase.getName();
-    }
-
     private static InfobaseReference infobaseOf(IProject project)
     {
         if (project == null || Activator.getDefault() == null)
@@ -85,27 +108,36 @@ public final class InfobaseAddress
         }
         try
         {
-            List<IApplication> applications = manager.getApplications(project);
-            if (applications == null)
+            InfobaseReference own = infobaseOfDefaultApplication(manager, project);
+            if (own != null)
+            {
+                return own;
+            }
+            IProject parent = BmCommonModuleGuards.parentProjectOf(project);
+            if (parent == null || !parent.exists() || !parent.isOpen())
             {
                 return null;
             }
-            for (IApplication application : applications)
-            {
-                if (application instanceof IInfobaseApplication)
-                {
-                    InfobaseReference infobase = ((IInfobaseApplication)application).getInfobase();
-                    if (infobase != null)
-                    {
-                        return infobase;
-                    }
-                }
-            }
+            return infobaseOfDefaultApplication(manager, parent);
         }
-        catch (RuntimeException wontSay)
+        catch (Exception wontSay)
         {
-            Activator.logDebug("infobase address: " + wontSay); //$NON-NLS-1$
+            // Logged rather than swallowed: without it the caller is told the project has no
+            // infobase, which is a different thing from "the question could not be asked".
+            Activator.logWarning("Could not place the infobase of " + project.getName() //$NON-NLS-1$
+                + ": " + wontSay.getMessage()); //$NON-NLS-1$
+            return null;
         }
-        return null;
+    }
+
+    private static InfobaseReference infobaseOfDefaultApplication(IApplicationManager manager,
+        IProject project)
+    {
+        Optional<IApplication> application = manager.getDefaultApplication(project);
+        if (application.isEmpty() || !(application.get() instanceof IInfobaseApplication))
+        {
+            return null;
+        }
+        return ((IInfobaseApplication)application.get()).getInfobase();
     }
 }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
@@ -1,0 +1,111 @@
+/**
+ * AI-EDT - 1C AI tools for EDT
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import java.util.List;
+
+import org.eclipse.core.resources.IProject;
+
+import com._1c.g5.v8.dt.platform.services.model.FileConnectionString;
+import com._1c.g5.v8.dt.platform.services.model.IConnectionString;
+import com._1c.g5.v8.dt.platform.services.model.InfobaseReference;
+import com.e1c.g5.dt.applications.IApplication;
+import com.e1c.g5.dt.applications.IApplicationManager;
+import com.e1c.g5.dt.applications.infobases.IInfobaseApplication;
+
+import ru.aiedt.mcp.server.Activator;
+
+/**
+ * Where a project's infobase is, in the words a 1C client understands.
+ * <p>
+ * A caller that has EDT open already told it which infobase the project belongs to - it is what
+ * update_database writes into and what start_client launches. Asking that caller to type a
+ * connection string as well makes them repeat what the environment knows, and a typed string can
+ * name a different infobase than the one the project is bound to.
+ * </p>
+ */
+public final class InfobaseAddress
+{
+    private InfobaseAddress() {}
+
+    /**
+     * The connection string of a project's infobase.
+     *
+     * @param project the project, possibly <code>null</code>.
+     * @return the connection string for a file infobase, or <code>null</code> when the project has
+     *         no infobase application, when EDT is not up, or when the infobase is not a file one -
+     *         a server infobase carries credentials this cannot supply
+     */
+    public static String ofProject(IProject project)
+    {
+        InfobaseReference infobase = infobaseOf(project);
+        if (infobase == null)
+        {
+            return null;
+        }
+        IConnectionString connection = infobase.getConnectionString();
+        if (!(connection instanceof FileConnectionString))
+        {
+            return null;
+        }
+        String file = ((FileConnectionString)connection).getFile();
+        if (file == null || file.trim().isEmpty())
+        {
+            return null;
+        }
+        return "File=\"" + file.trim() + "\";"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The name of a project's infobase, for an answer that says which one was used.
+     *
+     * @param project the project, possibly <code>null</code>.
+     * @return the name, or <code>null</code>
+     */
+    public static String nameOfProjectInfobase(IProject project)
+    {
+        InfobaseReference infobase = infobaseOf(project);
+        return infobase == null ? null : infobase.getName();
+    }
+
+    private static InfobaseReference infobaseOf(IProject project)
+    {
+        if (project == null || Activator.getDefault() == null)
+        {
+            return null;
+        }
+        IApplicationManager manager = Activator.getDefault().getApplicationManager();
+        if (manager == null)
+        {
+            return null;
+        }
+        try
+        {
+            List<IApplication> applications = manager.getApplications(project);
+            if (applications == null)
+            {
+                return null;
+            }
+            for (IApplication application : applications)
+            {
+                if (application instanceof IInfobaseApplication)
+                {
+                    InfobaseReference infobase = ((IInfobaseApplication)application).getInfobase();
+                    if (infobase != null)
+                    {
+                        return infobase;
+                    }
+                }
+            }
+        }
+        catch (RuntimeException wontSay)
+        {
+            Activator.logDebug("infobase address: " + wontSay); //$NON-NLS-1$
+        }
+        return null;
+    }
+}

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/InfobaseAddress.java
@@ -9,13 +9,16 @@ package ru.aiedt.mcp.server.support;
 import java.util.Optional;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.NullProgressMonitor;
 
 import com._1c.g5.v8.dt.platform.services.model.FileConnectionString;
 import com._1c.g5.v8.dt.platform.services.model.IConnectionString;
 import com._1c.g5.v8.dt.platform.services.model.InfobaseReference;
+import com._1c.g5.v8.dt.platform.services.core.infobases.sync.IInfobaseSynchronizationManager;
 import com.e1c.g5.dt.applications.IApplication;
 import com.e1c.g5.dt.applications.IApplicationManager;
 import com.e1c.g5.dt.applications.infobases.IInfobaseApplication;
+import com._1c.g5.wiring.ServiceAccess;
 
 import ru.aiedt.mcp.server.Activator;
 
@@ -38,7 +41,8 @@ public final class InfobaseAddress
      * @param connectionString what a 1C client is started with, or <code>null</code>.
      * @param name what the infobase is called in EDT, or <code>null</code>.
      */
-    public record Address(String connectionString, String name)
+    public record Address(String connectionString, String name, InfobaseReference infobase,
+        IProject owner)
     {
         /** @return whether an address was found */
         public boolean found()
@@ -48,7 +52,22 @@ public final class InfobaseAddress
     }
 
     /** Nothing found, so a caller reading this cannot mistake it for an address. */
-    private static final Address NOWHERE = new Address(null, null);
+    private static final Address NOWHERE = new Address(null, null, null, null);
+
+    /**
+     * An infobase and the project it belongs to.
+     * <p>
+     * The two travel together because they are not always the same project: an extension has
+     * no infobase of its own and belongs to the configuration above it, and EDT does not know
+     * the extension paired with the configuration infobase.
+     * </p>
+     *
+     * @param infobase the infobase.
+     * @param owner the project it belongs to.
+     */
+    private record Resolved(InfobaseReference infobase, IProject owner)
+    {
+    }
 
     /**
      * The infobase a project is bound to.
@@ -65,11 +84,12 @@ public final class InfobaseAddress
      */
     public static Address ofProject(IProject project)
     {
-        InfobaseReference infobase = infobaseOf(project);
-        if (infobase == null)
+        Resolved resolved = infobaseOf(project);
+        if (resolved == null)
         {
             return NOWHERE;
         }
+        InfobaseReference infobase = resolved.infobase();
         IConnectionString connection = infobase.getConnectionString();
         if (!(connection instanceof FileConnectionString))
         {
@@ -80,7 +100,8 @@ public final class InfobaseAddress
         {
             return NOWHERE;
         }
-        return new Address("File=\"" + file.trim() + "\";", infobase.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+        return new Address("File=\"" + file.trim() + "\";", infobase.getName(), //$NON-NLS-1$ //$NON-NLS-2$
+            infobase, resolved.owner());
     }
 
     /**
@@ -95,7 +116,7 @@ public final class InfobaseAddress
      * @param project the project.
      * @return the infobase, or <code>null</code>
      */
-    private static InfobaseReference infobaseOf(IProject project)
+    private static Resolved infobaseOf(IProject project)
     {
         if (project == null || Activator.getDefault() == null)
         {
@@ -111,14 +132,15 @@ public final class InfobaseAddress
             InfobaseReference own = infobaseOfDefaultApplication(manager, project);
             if (own != null)
             {
-                return own;
+                return new Resolved(own, project);
             }
             IProject parent = BmCommonModuleGuards.parentProjectOf(project);
             if (parent == null || !parent.exists() || !parent.isOpen())
             {
                 return null;
             }
-            return infobaseOfDefaultApplication(manager, parent);
+            InfobaseReference above = infobaseOfDefaultApplication(manager, parent);
+            return above == null ? null : new Resolved(above, parent);
         }
         catch (Exception wontSay)
         {
@@ -139,5 +161,139 @@ public final class InfobaseAddress
             return null;
         }
         return ((IInfobaseApplication)application.get()).getInfobase();
+    }
+
+    /**
+     * EDT let go of the project infobase, and will take it back when this is closed.
+     * <p>
+     * A file infobase admits one owner. While EDT holds the designer session on it, a client
+     * started against the same infobase does not connect: the process lives out its whole
+     * deadline without a single event reaching the infobase log, and what the caller sees is a
+     * run that timed out rather than one that never began.
+     * </p>
+     * <p>
+     * The infobase is taken back only when this released it. One the user had already
+     * disconnected stays disconnected, because connecting it back would change what they set
+     * up, and a disconnect of an already disconnected infobase succeeds silently and so cannot
+     * tell the two apart on its own.
+     * </p>
+     */
+    public static final class Hold implements AutoCloseable
+    {
+        private final IProject project;
+
+        private final InfobaseReference infobase;
+
+        private final boolean released;
+
+        private final String why;
+
+        private boolean takenBack;
+
+        private Hold(IProject project, InfobaseReference infobase, boolean released, String why)
+        {
+            this.project = project;
+            this.infobase = infobase;
+            this.released = released;
+            this.why = why;
+        }
+
+        /**
+         * Why nothing was released, for an answer that would otherwise blame the deadline.
+         *
+         * @return the reason, or <code>null</code> when there is nothing to say
+         */
+        public String why()
+        {
+            return why;
+        }
+
+        /**
+         * Whether EDT actually let go, so a caller can say why a launch may still be blocked.
+         *
+         * @return <code>true</code> when this released the infobase
+         */
+        public boolean released()
+        {
+            return released;
+        }
+
+        @Override
+        public void close()
+        {
+            // Once. A second close would connect an infobase the user may have disconnected
+            // by hand in between, undoing what they did.
+            if (!released || takenBack)
+            {
+                return;
+            }
+            takenBack = true;
+            IInfobaseSynchronizationManager manager =
+                ServiceAccess.get(IInfobaseSynchronizationManager.class);
+            if (manager == null)
+            {
+                return;
+            }
+            try
+            {
+                manager.connectInfobase(project, infobase, new NullProgressMonitor());
+            }
+            catch (Throwable failed)
+            {
+                Activator.logWarning("the infobase was not taken back and may show as " //$NON-NLS-1$
+                    + "disconnected in EDT - reconnect it there: " + failed); //$NON-NLS-1$
+            }
+        }
+    }
+
+    /**
+     * Has EDT let go of the project infobase for the duration of a client launch.
+     *
+     * @param project the project whose infobase the client opens; may be <code>null</code>.
+     * @return the hold, which takes the infobase back when closed
+     */
+    public static Hold release(Address address)
+    {
+        if (address == null || address.infobase() == null || address.owner() == null)
+        {
+            return new Hold(null, null, false, null);
+        }
+        IProject owner = address.owner();
+        InfobaseReference infobase = address.infobase();
+        IInfobaseSynchronizationManager manager =
+            ServiceAccess.get(IInfobaseSynchronizationManager.class);
+        if (manager == null)
+        {
+            return new Hold(owner, infobase, false,
+                "EDT has no infobase synchronization service, so the infobase it holds stays " //$NON-NLS-1$
+                    + "held"); //$NON-NLS-1$
+        }
+        try
+        {
+            boolean held = manager.isConnected(owner, infobase);
+            manager.disconnectInfobase(owner, infobase, false, true, new NullProgressMonitor());
+            return new Hold(owner, infobase, held, null);
+        }
+        catch (Throwable failed)
+        {
+            return new Hold(owner, infobase, false,
+                "the infobase EDT holds was not released: " + oneLine(failed)); //$NON-NLS-1$
+        }
+    }
+
+    /**
+     * What went wrong, on one line, for an answer that has room for a clause.
+     *
+     * @param failed the failure.
+     * @return its message
+     */
+    private static String oneLine(Throwable failed)
+    {
+        String said = failed.getMessage();
+        if (said == null || said.trim().isEmpty())
+        {
+            said = failed.getClass().getSimpleName();
+        }
+        return said.replace("\n", " ").trim(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
@@ -413,7 +413,7 @@ public class EditMetadataTool implements IMcpTool
                 "Plain-text body of a TextDocument or HTMLDocument template - filled on create, replaced by " //$NON-NLS-1$
                 + "set_template_content, returned by get_template_content. Spreadsheets go through mxl_workshop " //$NON-NLS-1$
                 + "and DCS through dcs_workshop.") //$NON-NLS-1$ //$NON-NLS-1$
-            // Wave F: create_route_map parameters (BusinessProcess Flowchart.scheme).
+            // create_route_map parameters (BusinessProcess Flowchart.scheme).
             .stringProperty("points", //$NON-NLS-1$
                 "create_route_map: JSON array of route points, laid out top to bottom. Needs exactly one " //$NON-NLS-1$
                 + "Start and at least one Completion. Full text: operation=help topic=parameters.") //$NON-NLS-1$ //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -162,6 +162,10 @@ public class VanessaTool implements IMcpTool
                 "Name of the 1C user the run signs in as. A base with users defined meets a " //$NON-NLS-1$
                     + "client that names none with a login window, and the run then waits out " //$NON-NLS-1$
                     + "its whole deadline. A password cannot be passed here.") //$NON-NLS-1$
+            .booleanProperty("testManager", //$NON-NLS-1$
+                "Start the client as a test manager (default false). The UI-testing types a " //$NON-NLS-1$
+                    + "form-driving scenario needs exist only in a client started this way; " //$NON-NLS-1$
+                    + "without it such a step answers Тип не определен.") //$NON-NLS-1$
             .booleanProperty("testClient", //$NON-NLS-1$
                 "Name a test client in VAParams for the start step to launch (default false). " //$NON-NLS-1$
                     + "Measured on one stand: with the block present Vanessa writes no report " //$NON-NLS-1$
@@ -391,6 +395,8 @@ public class VanessaTool implements IMcpTool
                 + "a port is 1 to " + HIGHEST_PORT + ". Read as a number it cannot be, the " //$NON-NLS-1$ //$NON-NLS-2$
                 + "run would have started on the default port instead of the one named.").toJson(); //$NON-NLS-1$
         }
+        final boolean settledWantsManager =
+            JsonUtils.extractBooleanArgument(params, "testManager", false); //$NON-NLS-1$
         final boolean settledWantsTestClient =
             JsonUtils.extractBooleanArgument(params, "testClient", false); //$NON-NLS-1$
         final int settledClientPort = namedPort != null ? namedPort.intValue() : TEST_CLIENT_PORT;
@@ -432,7 +438,7 @@ public class VanessaTool implements IMcpTool
             return play(settledExe, settledEpf, settledConnection, settledFeature, composedScenario,
                 screenshots, keepOpen, stepDelay, settledTimeout, settledClientPort,
                 extraVaParams, runDirForJob, null, settledInfobase, settledAddress,
-                settledWantsTestClient);
+                settledWantsTestClient, settledWantsManager);
         }
         PendingWorkRegistry registry = PendingWorkRegistry.VANESSA;
         registry.pruneExpired();
@@ -451,7 +457,7 @@ public class VanessaTool implements IMcpTool
                 () -> play(settledExe, settledEpf, settledConnection, settledFeature,
                     composedScenario, screenshots, keepOpen, stepDelay, settledTimeout,
                     settledClientPort, extraVaParams, runDirForJob, jobKey, settledInfobase,
-                    settledAddress, settledWantsTestClient));
+                    settledAddress, settledWantsTestClient, settledWantsManager));
         }
         String done = entry.await(ASYNC_FIRST_WAIT_MS);
         if (done != null)
@@ -494,12 +500,14 @@ public class VanessaTool implements IMcpTool
      * @param infobaseAddress the infobase EDT holds, as it was resolved once, or
      *            <code>null</code> when the caller named the connection string itself.
      * @param withTestClient whether to name a test client for the start step to launch.
+     * @param asTestManager whether the client is started as a test manager.
      * @return the answer
      */
     private String play(File exeFile, File epfFile, String connectionString, File featurePath,
         String composedScenario, boolean screenshots, boolean keepOpen, int stepDelay,
         int timeoutSec, int clientPort, JsonObject extraVaParams, File workingDir, String jobKey,
-        String infobaseName, InfobaseAddress.Address infobaseAddress, boolean withTestClient)
+        String infobaseName, InfobaseAddress.Address infobaseAddress, boolean withTestClient,
+        boolean asTestManager)
     {
         String refused = refusedBeforeLaunch(jobKey);
         if (refused != null)
@@ -555,7 +563,8 @@ public class VanessaTool implements IMcpTool
             writeUtf8Bom(paramsFile, vaParamsJson);
 
             File runDir = workingDir != null ? workingDir : outDir.toFile();
-            List<String> command = buildCommand(exeFile, connectionString, epfFile, paramsFile);
+            List<String> command =
+                buildCommand(exeFile, connectionString, epfFile, paramsFile, asTestManager);
             // The connectionString may carry Pwd="..." - never log it in the clear.
             Activator.logInfo("vanessa: launching " + redactSecrets(String.join(" ", command)) //$NON-NLS-1$ //$NON-NLS-2$
                 + "\nVAParams.json keys: " + keysOf(vaParamsJson)); //$NON-NLS-1$
@@ -858,7 +867,7 @@ public class VanessaTool implements IMcpTool
      * A scenario that opens one form and has it photographed.
      * <p>
      * The snapshot is not a step. Vanessa takes one before and after the step that follows the
-     * {@code @screenshot} tag, writing them where {@code КаталогСохраненияСкриншотов} points - which
+     * {@code @screenshot} tag, writing them where {@code КаталогOutputСкриншоты} points - which
      * this tool already sets for every run, and which the report reader already groups by step.
      * </p>
      * <p>
@@ -1021,10 +1030,14 @@ public class VanessaTool implements IMcpTool
         o.addProperty("ДелатьОтчетВФорматеАллюр", true); //$NON-NLS-1$
         o.addProperty("КаталогOutputAllureБазовый", //$NON-NLS-1$
             junitFile.getAbsoluteFile().getParentFile().getAbsolutePath());
-        o.addProperty("ДелатьСкриншотПриОшибке", screenshots); //$NON-NLS-1$
-        o.addProperty("КаталогСохраненияСкриншотов", shotsDir.getAbsolutePath()); //$NON-NLS-1$
-        o.addProperty("ЗакрыватьTestClientПослеПрогона", !keepOpen); //$NON-NLS-1$
-        o.addProperty("ВыходИзПриложенияПослеЗапускаСценариев", !keepOpen); //$NON-NLS-1$
+        // The names Vanessa documents. Under any others it writes no screenshots and says
+        // nothing, exactly as it wrote no report while the JUnit names were used.
+        o.addProperty("ДелатьСкриншотПриВозникновенииОшибки", screenshots); //$NON-NLS-1$
+        o.addProperty("КаталогOutputСкриншоты", shotsDir.getAbsolutePath()); //$NON-NLS-1$
+        // The names Vanessa documents. Under any others the run ends when Vanessa itself
+        // decides to, and the test client it started is left behind.
+        o.addProperty("ЗакрытьTestClientПослеЗапускаСценариев", !keepOpen); //$NON-NLS-1$
+        o.addProperty("ЗавершитьРаботуСистемы", !keepOpen); //$NON-NLS-1$
         if (stepDelay > 0)
         {
             o.addProperty("ПаузаМеждуШагами", stepDelay); //$NON-NLS-1$
@@ -1144,9 +1157,8 @@ public class VanessaTool implements IMcpTool
      * </p>
      */
     private static final java.util.Set<String> OURS_TO_SET = lowerCased(
-        "СохранятьРезультатыВФорматеJUnit", "ПутьКФайлуРезультатовJUnit", //$NON-NLS-1$ //$NON-NLS-2$
-        "КаталогСохраненияСкриншотов", "ЗакрыватьTestClientПослеПрогона", //$NON-NLS-1$ //$NON-NLS-2$
-        "ВыходИзПриложенияПослеЗапускаСценариев", //$NON-NLS-1$
+        "ДелатьОтчетВФорматеАллюр", "КаталогOutputAllureБазовый", //$NON-NLS-1$ //$NON-NLS-2$
+        "ЗакрытьTestClientПослеЗапускаСценариев", "ЗавершитьРаботуСистемы", //$NON-NLS-1$ //$NON-NLS-2$
         // Turned off, Vanessa opens its window and waits there: the run spends its whole budget on
         // a form nobody is looking at and writes no report.
         "ВыполнитьСценарии", //$NON-NLS-1$
@@ -1157,7 +1169,8 @@ public class VanessaTool implements IMcpTool
         // These come from arguments of this tool. Letting the passthrough set them too would mean
         // the later one silently wins, and the caller who passed screenshots=true would be told it
         // ran with screenshots while it did not.
-        "КаталогФич", "ФайлСценария", "ДелатьСкриншотПриОшибке", "ПаузаМеждуШагами"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+        "КаталогФич", "ФайлСценария", "ДелатьСкриншотПриВозникновенииОшибки", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        "КаталогOutputСкриншоты", "ПаузаМеждуШагами"); //$NON-NLS-1$ //$NON-NLS-2$
 
     /**
      * Field names a connection string carries a password under that no rule would catch.
@@ -1339,7 +1352,7 @@ public class VanessaTool implements IMcpTool
     }
 
     private static List<String> buildCommand(File exe, String connectionString, File epf,
-        File paramsFile)
+        File paramsFile, boolean asTestManager)
     {
         List<String> c = new ArrayList<>();
         c.add(exe.getAbsolutePath());
@@ -1347,6 +1360,12 @@ public class VanessaTool implements IMcpTool
         c.add("/IBConnectionString"); //$NON-NLS-1$
         c.add(connectionString);
         c.add("/DisableStartupMessages"); //$NON-NLS-1$
+        if (asTestManager)
+        {
+            // The UI-testing types exist only in a client started this way. Without it a step
+            // that drives a form answers "Тип не определен" and the scenario stops there.
+            c.add("/TESTMANAGER"); //$NON-NLS-1$
+        }
         c.add("/Execute"); //$NON-NLS-1$
         c.add(epf.getAbsolutePath());
         c.add("/C"); //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -60,8 +60,8 @@ import com.google.gson.JsonObject;
  * <p><b>Tier-1 (synchronous)</b>: the run blocks up to {@code timeoutSeconds};
  * a very long suite should raise the timeout. The Vanessa launch parameters
  * (the {@code /C} command and the {@code VAParams.json} keys) are Vanessa-version
- * sensitive - the full command line and the settings file are always logged so
- * they can be reconciled against the installed Vanessa build.
+ * sensitive - the command line and the key names of the settings file are logged so they can
+ * be reconciled against the installed Vanessa build. Values are not: one may carry a secret.
  */
 public class VanessaTool implements IMcpTool
 {
@@ -154,6 +154,9 @@ public class VanessaTool implements IMcpTool
                     + "working directory.") //$NON-NLS-1$
             .integerProperty("timeoutSeconds", //$NON-NLS-1$
                 "Max seconds to wait for the run (default 300, max 3600).") //$NON-NLS-1$
+            .integerProperty("testClientPort", //$NON-NLS-1$
+                "Port the test client listens on (default 48010). Name another when a second " //$NON-NLS-1$
+                    + "run or another EDT already holds it.") //$NON-NLS-1$
             .booleanProperty("screenshots", //$NON-NLS-1$
                 "Capture a screenshot on step failure (default true).") //$NON-NLS-1$
             .booleanProperty("keepOpen", //$NON-NLS-1$
@@ -362,6 +365,19 @@ public class VanessaTool implements IMcpTool
         boolean keepOpen = JsonUtils.extractBooleanArgument(params, "keepOpen", false); //$NON-NLS-1$
         int stepDelay = Math.max(0, JsonUtils.extractIntArgument(params, "stepDelaySeconds", 0)); //$NON-NLS-1$
         int timeoutSec = JsonUtils.extractIntArgument(params, "timeoutSeconds", DEFAULT_TIMEOUT_SEC); //$NON-NLS-1$
+        Integer namedPort = JsonUtils.extractIntegerArgument(params, "testClientPort"); //$NON-NLS-1$
+        if (namedPort == null && params != null && params.containsKey("testClientPort")) //$NON-NLS-1$
+        {
+            return ToolResult.error("testClientPort is not a whole number a port can be: " //$NON-NLS-1$
+                + "a port is 1 to " + HIGHEST_PORT + ". Read as a number it cannot be, the " //$NON-NLS-1$ //$NON-NLS-2$
+                + "run would have started on the default port instead of the one named.").toJson(); //$NON-NLS-1$
+        }
+        final int settledClientPort = namedPort != null ? namedPort.intValue() : TEST_CLIENT_PORT;
+        String portRefusal = whyThePortCannotBeUsed(settledClientPort);
+        if (portRefusal != null)
+        {
+            return ToolResult.error(portRefusal).toJson();
+        }
         if (timeoutSec <= 0)
         {
             timeoutSec = DEFAULT_TIMEOUT_SEC;
@@ -393,8 +409,8 @@ public class VanessaTool implements IMcpTool
             // run with these same arguments owns this key. Registering both under it would let a
             // cancel meant for that run destroy this client instead.
             return play(settledExe, settledEpf, settledConnection, settledFeature, composedScenario,
-                screenshots, keepOpen, stepDelay, settledTimeout, extraVaParams, runDirForJob,
-                null, settledInfobase);
+                screenshots, keepOpen, stepDelay, settledTimeout, settledClientPort,
+                extraVaParams, runDirForJob, null, settledInfobase);
         }
         PendingWorkRegistry registry = PendingWorkRegistry.VANESSA;
         registry.pruneExpired();
@@ -412,7 +428,7 @@ public class VanessaTool implements IMcpTool
             entry = registry.getOrStart(jobKey,
                 () -> play(settledExe, settledEpf, settledConnection, settledFeature,
                     composedScenario, screenshots, keepOpen, stepDelay, settledTimeout,
-                    extraVaParams, runDirForJob, jobKey, settledInfobase));
+                    settledClientPort, extraVaParams, runDirForJob, jobKey, settledInfobase));
         }
         String done = entry.await(ASYNC_FIRST_WAIT_MS);
         if (done != null)
@@ -445,7 +461,8 @@ public class VanessaTool implements IMcpTool
      * @param screenshots whether to capture one when a step fails.
      * @param keepOpen whether to leave the client running afterwards.
      * @param stepDelay the pause between steps, in seconds.
-     * @param timeoutSec how long to wait for the client.
+     * @param timeoutSec how long to wait for the run.
+     * @param clientPort the port the test client listens on.
      * @param extraVaParams what the caller added to the Vanessa document.
      * @param workingDir where to run.
      * @param jobKey the key this run is cancelled by.
@@ -455,7 +472,7 @@ public class VanessaTool implements IMcpTool
      */
     private String play(File exeFile, File epfFile, String connectionString, File featurePath,
         String composedScenario, boolean screenshots, boolean keepOpen, int stepDelay,
-        int timeoutSec, JsonObject extraVaParams, File workingDir, String jobKey,
+        int timeoutSec, int clientPort, JsonObject extraVaParams, File workingDir, String jobKey,
         String infobaseName)
     {
         String refused = refusedBeforeLaunch(jobKey);
@@ -507,7 +524,7 @@ public class VanessaTool implements IMcpTool
             }
 
             String vaParamsJson = buildVaParams(playing, junitFile, shotsDir, screenshots,
-                keepOpen, stepDelay, extraVaParams);
+                keepOpen, stepDelay, connectionString, clientPort, timeoutSec, extraVaParams);
             writeUtf8Bom(paramsFile, vaParamsJson);
 
             File runDir = workingDir != null ? workingDir : outDir.toFile();
@@ -551,7 +568,8 @@ public class VanessaTool implements IMcpTool
                 return ToolResult.error("Vanessa produced no JUnit report (exit " + pr.exitCode //$NON-NLS-1$
                     + "). The run may not have started (bad connectionString, an unadopted Vanessa " //$NON-NLS-1$
                     + "extension in the infobase, a login window, or Vanessa-version-specific launch " //$NON-NLS-1$
-                    + "parameters - the launched command and VAParams.json are in the EDT .log). " //$NON-NLS-1$
+                    + "parameters - the launched command and the key names of VAParams.json " //$NON-NLS-1$
+                    + "are in the EDT .log). " //$NON-NLS-1$
                     + (incomplete == null ? "" : incomplete + " ") //$NON-NLS-1$
                     + tail(pr.output))
                     .put("composedScenarioLeftBehind", leftBehind).toJson(); //$NON-NLS-1$
@@ -865,14 +883,39 @@ public class VanessaTool implements IMcpTool
     }
 
     /**
-     * The Vanessa {@code VAParams.json} (Russian keys - Vanessa-version sensitive, logged
-     * verbatim). Points Vanessa at the feature path, asks for a JUnit report and (optional)
-     * failure screenshots, and closes the client when done so the poller detects exit.
+     * The Vanessa {@code VAParams.json} (Russian keys - Vanessa-version sensitive). Points
+     * Vanessa at the feature path, names the test client the start step launches, asks for a
+     * JUnit report and (optional) failure screenshots, and closes the client when done so the
+     * poller detects exit. Only the key names of the result are logged: a value may carry a
+     * secret.
+     *
+     * @param featurePath the scenarios, a file or a directory of them.
+     * @param junitFile where Vanessa writes the report this run is read from.
+     * @param shotsDir where Vanessa writes failure screenshots.
+     * @param screenshots whether to capture one when a step fails.
+     * @param keepOpen whether to leave the client running afterwards.
+     * @param stepDelay the pause between steps, in seconds; zero leaves the key out.
+     * @param connectionString the infobase the test client opens.
+     * @param clientPort the port the test client listens on.
+     * @param clientTimeoutSec the whole budget of the run; the client share of it is taken by
+     *            {@link #clientWaitWithin(int)}.
+     * @param extra what the caller added to the Vanessa document, merged last.
+     * @return the document, ready to be written
      */
-    private static String buildVaParams(File featurePath, File junitFile, File shotsDir,
-        boolean screenshots, boolean keepOpen, int stepDelay, JsonObject extra)
+    static String buildVaParams(File featurePath, File junitFile, File shotsDir,
+        boolean screenshots, boolean keepOpen, int stepDelay, String connectionString,
+        int clientPort, int clientTimeoutSec, JsonObject extra)
     {
         JsonObject o = new JsonObject();
+        // The step that starts TestClient has no client to start without this block: the run
+        // answers "Тип не определен (ТестируемаяГруппаФормы)" with an empty client type and PID 0,
+        // because the UI-testing types exist only once a client runs under the test manager.
+        o.add("TestClient", //$NON-NLS-1$
+            testClient(connectionString, clientPort, clientWaitWithin(clientTimeoutSec)));
+        // Without this Vanessa opens its own window and waits there. Every run then spends its
+        // whole time budget on a form nobody is looking at, ends killed, and writes no report -
+        // which reads exactly like a scenario that never started.
+        o.addProperty("ВыполнитьСценарии", true); //$NON-NLS-1$
         // A directory of features, or the parent of a single .feature file.
         // getAbsoluteFile() first so getParentFile() is non-null even for a bare filename.
         File dir = featurePath.isDirectory() ? featurePath : featurePath.getAbsoluteFile().getParentFile();
@@ -901,6 +944,97 @@ public class VanessaTool implements IMcpTool
         return prettyJson(o);
     }
 
+    /** The port the test client listens on when the caller names none. */
+    static final int TEST_CLIENT_PORT = 48010;
+
+    /**
+     * The longest the run waits for the test client to answer. A client that has not come up
+     * within this is not coming, and without a ceiling a long suite would spend its whole
+     * budget waiting for one that never will.
+     */
+    static final int TEST_CLIENT_WAIT_CEILING_SEC = 600;
+
+    /**
+     * Why the test client cannot be told to listen on the given port.
+     * <p>
+     * Vanessa writes the number down as it is given, and a client told to listen on a number
+     * that is not a port simply does not listen - the start step then fails for a reason that
+     * names neither the port nor this tool.
+     * </p>
+     *
+     * @param port the port the caller named.
+     * @return the refusal, or <code>null</code> when the port can be used
+     */
+    static String whyThePortCannotBeUsed(int port)
+    {
+        if (port >= 1 && port <= HIGHEST_PORT)
+        {
+            return null;
+        }
+        return "testClientPort is " + port + ", which is not a port: a port is 1 to " //$NON-NLS-1$ //$NON-NLS-2$
+            + HIGHEST_PORT + ". Vanessa writes the number down as given, and a client told to " //$NON-NLS-1$
+            + "listen on it does not listen."; //$NON-NLS-1$
+    }
+
+    /** The highest port a client can be told to listen on. */
+    static final int HIGHEST_PORT = 65535;
+
+    /** The most that is held back for Vanessa to write its report and exit. */
+    private static final int REPORT_RESERVE_CEILING_SEC = 60;
+
+    /** The share of a small budget held back, when a whole minute would be most of it. */
+    private static final int RESERVE_SHARE = 3;
+
+    /**
+     * Seconds Vanessa waits for the test client, out of the run's own budget.
+     * <p>
+     * Kept under the budget so Vanessa reaches its own timeout, writes the report and exits
+     * before this tool kills the process, and under a ceiling so a long suite does not spend
+     * all of its time on a client that is not coming. What is held back is a third of the
+     * budget or a minute, whichever is smaller, so a short run keeps a reserve too.
+     * </p>
+     *
+     * @param budgetSec the whole budget of the run.
+     * @return the seconds to wait for the client
+     */
+    static int clientWaitWithin(int budgetSec)
+    {
+        // A whole minute is most of a small budget, so what is held back is a share of it
+        // until the budget is large enough for the minute to be the smaller of the two.
+        int reserve = Math.min(REPORT_RESERVE_CEILING_SEC,
+            Math.max(1, budgetSec / RESERVE_SHARE));
+        return Math.max(1, Math.min(budgetSec - reserve, TEST_CLIENT_WAIT_CEILING_SEC));
+    }
+
+    /**
+     * The {@code TestClient} block of VAParams: which infobase the client opens, on which port and
+     * as which client type.
+     *
+     * @param connectionString the infobase the test client opens.
+     * @param clientPort the port the client listens on.
+     * @param clientTimeoutSec seconds Vanessa waits for the client to answer. Taken from the
+     *            run's own budget up to {@link #TEST_CLIENT_WAIT_CEILING_SEC}.
+     * @return the block, holding one client
+     */
+    static JsonObject testClient(String connectionString, int clientPort, int clientTimeoutSec)
+    {
+        JsonObject client = new JsonObject();
+        client.addProperty("Name", "AiEdt"); //$NON-NLS-1$ //$NON-NLS-2$
+        client.addProperty("PathToInfobase", connectionString); //$NON-NLS-1$
+        client.addProperty("PortTestClient", clientPort); //$NON-NLS-1$
+        // Vanessa spells this key with that capital I. Correcting it leaves the key unread.
+        client.addProperty("AddItionalParameters", ""); //$NON-NLS-1$ //$NON-NLS-2$
+        client.addProperty("ClientType", "Thin"); //$NON-NLS-1$ //$NON-NLS-2$
+        client.addProperty("ComputerName", "localhost"); //$NON-NLS-1$ //$NON-NLS-2$
+        com.google.gson.JsonArray clients = new com.google.gson.JsonArray();
+        clients.add(client);
+        JsonObject block = new JsonObject();
+        block.addProperty("runtestclientwithmaximizedwindow", true); //$NON-NLS-1$
+        block.addProperty("testclienttimeout", clientTimeoutSec); //$NON-NLS-1$
+        block.add("datatestclients", clients); //$NON-NLS-1$
+        return block;
+    }
+
     /**
      * {@code 1cv8 ENTERPRISE /IBConnectionString "<conn>" /DisableStartupMessages
      * /Execute <epf> /C "StartFeaturePlayer;VAParams=<params>"} (thick client;
@@ -918,6 +1052,13 @@ public class VanessaTool implements IMcpTool
         "СохранятьРезультатыВФорматеJUnit", "ПутьКФайлуРезультатовJUnit", //$NON-NLS-1$ //$NON-NLS-2$
         "КаталогСохраненияСкриншотов", "ЗакрыватьTestClientПослеПрогона", //$NON-NLS-1$ //$NON-NLS-2$
         "ВыходИзПриложенияПослеЗапускаСценариев", //$NON-NLS-1$
+        // Turned off, Vanessa opens its window and waits there: the run spends its whole budget on
+        // a form nobody is looking at and writes no report.
+        "ВыполнитьСценарии", //$NON-NLS-1$
+        // The passthrough takes values and lists of them, so it cannot carry the object this block
+        // needs; what it can carry is a value that replaces the block with something the start step
+        // cannot use. Its port and its deadline are arguments of this tool instead.
+        "TestClient", //$NON-NLS-1$
         // These come from arguments of this tool. Letting the passthrough set them too would mean
         // the later one silently wins, and the caller who passed screenshots=true would be told it
         // ran with screenshots while it did not.
@@ -1029,9 +1170,9 @@ public class VanessaTool implements IMcpTool
             // set to Turkish, and a protected name stops matching.
             if (OURS_TO_SET.contains(key.toLowerCase(java.util.Locale.ROOT)))
             {
-                refusal[0] = "'" + key + "' is set by this tool, because it reads the run's " //$NON-NLS-1$ //$NON-NLS-2$
-                    + "result back from where it points. Moving it would leave the run reporting " //$NON-NLS-1$
-                    + "success while reading nothing."; //$NON-NLS-1$
+                refusal[0] = "'" + key + "' is set by this tool, from its own " //$NON-NLS-1$ //$NON-NLS-2$
+                    + "arguments. Passing it here as well would leave the answer describing a " //$NON-NLS-1$
+                    + "run that did not happen the way it says."; //$NON-NLS-1$
                 return null;
             }
             if (!isAValueOrAListOfThem(given.get(key)))

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -547,10 +547,12 @@ public class VanessaTool implements IMcpTool
                         + " " + tail(pr.output))
                         .put("composedScenarioLeftBehind", leftBehind).toJson(); //$NON-NLS-1$
                 }
+                String incomplete = whatTheDistributionIsMissing(epfFile);
                 return ToolResult.error("Vanessa produced no JUnit report (exit " + pr.exitCode //$NON-NLS-1$
                     + "). The run may not have started (bad connectionString, an unadopted Vanessa " //$NON-NLS-1$
                     + "extension in the infobase, a login window, or Vanessa-version-specific launch " //$NON-NLS-1$
                     + "parameters - the launched command and VAParams.json are in the EDT .log). " //$NON-NLS-1$
+                    + (incomplete == null ? "" : incomplete + " ") //$NON-NLS-1$
                     + tail(pr.output))
                     .put("composedScenarioLeftBehind", leftBehind).toJson(); //$NON-NLS-1$
             }
@@ -718,6 +720,57 @@ public class VanessaTool implements IMcpTool
             return "openStep is one step and therefore one line."; //$NON-NLS-1$
         }
         return null;
+    }
+
+    /** Folders the multi-file distribution loads from beside its own file. */
+    private static final String[] COMPANIONS = { "locales", "lib" }; //$NON-NLS-1$ //$NON-NLS-2$
+
+    /**
+     * What a Vanessa distribution is missing beside its own file, or <code>null</code>.
+     * <p>
+     * Vanessa ships two ways. The single-file build carries everything; the ordinary one loads
+     * companion processors from {@code locales} and {@code lib} next to itself and, when they are
+     * not there, opens a modal naming a file nobody asked about and produces no report. The run
+     * then spends its whole time budget waiting on a window, and the answer is a list of guesses -
+     * none of which is the true one.
+     * </p>
+     * <p>
+     * Only said when it is certainly true: a folder that is absent or empty beside a file whose
+     * name does not mark it as the single-file build.
+     * </p>
+     *
+     * @param epf the configured data processor.
+     * @return the sentence to add to a failure, or <code>null</code> when nothing is missing
+     */
+    static String whatTheDistributionIsMissing(File epf)
+    {
+        if (epf == null || epf.getName().toLowerCase().contains("-single")) //$NON-NLS-1$
+        {
+            return null;
+        }
+        File beside = epf.getParentFile();
+        if (beside == null)
+        {
+            return null;
+        }
+        List<String> missing = new ArrayList<>();
+        for (String companion : COMPANIONS)
+        {
+            File folder = new File(beside, companion);
+            String[] inside = folder.list();
+            if (!folder.isDirectory() || inside == null || inside.length == 0)
+            {
+                missing.add(companion);
+            }
+        }
+        if (missing.isEmpty())
+        {
+            return null;
+        }
+        return "This distribution is incomplete: " + String.join(" and ", missing) //$NON-NLS-1$ //$NON-NLS-2$
+            + " beside " + epf.getName() + (missing.size() == 1 ? " is" : " are") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + " missing or empty, and Vanessa loads companion processors from there before it " //$NON-NLS-1$
+            + "runs anything. Point the preference at the single-file build instead."; //$NON-NLS-1$
     }
 
     /** How the scenario opens a form when the caller does not say otherwise. */

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -279,10 +279,11 @@ public class VanessaTool implements IMcpTool
             String projectForInfobase = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
             IProject project = projectForInfobase == null || projectForInfobase.trim().isEmpty()
                 ? null : ProjectResolver.resolve(projectForInfobase);
-            connectionString = InfobaseAddress.ofProject(project);
-            if (connectionString != null)
+            InfobaseAddress.Address address = InfobaseAddress.ofProject(project);
+            if (address.found())
             {
-                infobaseFrom = InfobaseAddress.nameOfProjectInfobase(project);
+                connectionString = address.connectionString();
+                infobaseFrom = address.name();
             }
         }
         if (connectionString == null || connectionString.trim().isEmpty())
@@ -317,9 +318,14 @@ public class VanessaTool implements IMcpTool
         }
         if (hasForm)
         {
-            scenarioText = scenarioForForm(formToOpen.trim(),
-                JsonUtils.extractStringArgument(params, "startStep"), //$NON-NLS-1$
-                JsonUtils.extractStringArgument(params, "openStep")); //$NON-NLS-1$
+            String openStep = JsonUtils.extractStringArgument(params, "openStep"); //$NON-NLS-1$
+            String startStep = JsonUtils.extractStringArgument(params, "startStep"); //$NON-NLS-1$
+            String badlyFormed = whyTheFormCannotBeNamed(formToOpen, openStep, startStep);
+            if (badlyFormed != null)
+            {
+                return ToolResult.error(badlyFormed).toJson();
+            }
+            scenarioText = scenarioForForm(formToOpen.trim(), startStep, openStep);
             hasText = true;
         }
 
@@ -655,6 +661,61 @@ public class VanessaTool implements IMcpTool
         {
             return "featurePath is required (a .feature file or a directory), or scenarioText " //$NON-NLS-1$
                 + "with the scenario itself, or formToOpen with the form to open and snapshot."; //$NON-NLS-1$
+        }
+        return null;
+    }
+
+    /**
+     * Why a form cannot be put into a scenario, or <code>null</code> when it can.
+     * <p>
+     * The name goes into a Gherkin step, and a step is one line with the name usually in quotes. A
+     * name carrying a quote or a line break composes a scenario Vanessa reads as something else -
+     * and the run then fails somewhere far from the cause, or worse, succeeds having done the
+     * wrong thing.
+     * </p>
+     *
+     * @param form the form the caller named.
+     * @param openStep the wording, or <code>null</code> for the default.
+     * @return the refusal, or <code>null</code>
+     */
+    static String whyTheFormCannotBeNamed(String form, String openStep)
+    {
+        return whyTheFormCannotBeNamed(form, openStep, null);
+    }
+
+    /**
+     * Why a form cannot be put into a scenario, or <code>null</code> when it can.
+     *
+     * @param form the form the caller named.
+     * @param openStep the wording that opens it, or <code>null</code> for the default.
+     * @param startStep the wording that gets a client, or <code>null</code> for the default.
+     * @return the refusal, or <code>null</code>
+     */
+    static String whyTheFormCannotBeNamed(String form, String openStep, String startStep)
+    {
+        if (startStep != null && (startStep.indexOf('\n') >= 0 || startStep.indexOf('\r') >= 0))
+        {
+            return "startStep is one step and therefore one line."; //$NON-NLS-1$
+        }
+        if (form == null || form.trim().isEmpty())
+        {
+            return "formToOpen is empty. Name the form the opening step expects."; //$NON-NLS-1$
+        }
+        if (form.indexOf('"') >= 0 || form.indexOf('\n') >= 0 || form.indexOf('\r') >= 0)
+        {
+            return "formToOpen carries a quote or a line break, and the name goes into one line " //$NON-NLS-1$
+                + "of a scenario. Pass the name alone, or write the whole scenario in " //$NON-NLS-1$
+                + "scenarioText."; //$NON-NLS-1$
+        }
+        String wording = openStep == null || openStep.trim().isEmpty() ? OPEN_STEP : openStep;
+        if (!wording.contains("{form}")) //$NON-NLS-1$
+        {
+            return "openStep does not say where the form name goes. Put {form} in it, as in " //$NON-NLS-1$
+                + OPEN_STEP + "."; //$NON-NLS-1$
+        }
+        if (wording.indexOf('\n') >= 0 || wording.indexOf('\r') >= 0)
+        {
+            return "openStep is one step and therefore one line."; //$NON-NLS-1$
         }
         return null;
     }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -273,7 +273,7 @@ public class VanessaTool implements IMcpTool
         {
             return ToolResult.error("Configured Vanessa Automation .epf not found: " + epf).toJson(); //$NON-NLS-1$
         }
-        File exeFile = theClientToLaunch(new File(exe));
+        File exeFile = new File(exe);
         if (!exeFile.isFile())
         {
             return ToolResult.error("Configured 1C thick client not found: " + exe).toJson(); //$NON-NLS-1$
@@ -872,43 +872,6 @@ public class VanessaTool implements IMcpTool
             + "    @screenshot\n" //$NON-NLS-1$
             + "    Когда " + opening.replace("{form}", form) + "\n" //$NON-NLS-1$ //$NON-NLS-2$
             + "    И Я закрываю все окна клиентского приложения\n"; //$NON-NLS-1$
-    }
-
-    /** What the platform calls its thin client. */
-    private static final String THIN_CLIENT = "1cv8c.exe"; //$NON-NLS-1$
-
-    /** What the platform calls the client that is both. */
-    private static final String EITHER_CLIENT = "1cv8.exe"; //$NON-NLS-1$
-
-    /**
-     * The client to launch: the thin one beside the configured executable when it is there.
-     * <p>
-     * Measured on an infobase the client could not open, because EDT held the file: 1cv8.exe
-     * waits without showing anything and has to be killed at the deadline, while 1cv8c.exe
-     * reaches the login, says the file access mode is wrong and exits. A run that ends with a
-     * reason beats one that ends with a deadline.
-     * </p>
-     * <p>
-     * Vanessa drives a thin client either way - the TestClient block written above names
-     * ClientType Thin. A preference already pointing at the thin client is left alone.
-     * </p>
-     *
-     * @param configured what the preference names.
-     * @return the thin client beside it, or the configured one when there is none
-     */
-    static File theClientToLaunch(File configured)
-    {
-        if (configured == null || !EITHER_CLIENT.equalsIgnoreCase(configured.getName()))
-        {
-            return configured;
-        }
-        File beside = configured.getParentFile();
-        if (beside == null)
-        {
-            return configured;
-        }
-        File thin = new File(beside, THIN_CLIENT);
-        return thin.isFile() ? thin : configured;
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -273,7 +273,7 @@ public class VanessaTool implements IMcpTool
         {
             return ToolResult.error("Configured Vanessa Automation .epf not found: " + epf).toJson(); //$NON-NLS-1$
         }
-        File exeFile = new File(exe);
+        File exeFile = theClientToLaunch(new File(exe));
         if (!exeFile.isFile())
         {
             return ToolResult.error("Configured 1C thick client not found: " + exe).toJson(); //$NON-NLS-1$
@@ -872,6 +872,43 @@ public class VanessaTool implements IMcpTool
             + "    @screenshot\n" //$NON-NLS-1$
             + "    Когда " + opening.replace("{form}", form) + "\n" //$NON-NLS-1$ //$NON-NLS-2$
             + "    И Я закрываю все окна клиентского приложения\n"; //$NON-NLS-1$
+    }
+
+    /** What the platform calls its thin client. */
+    private static final String THIN_CLIENT = "1cv8c.exe"; //$NON-NLS-1$
+
+    /** What the platform calls the client that is both. */
+    private static final String EITHER_CLIENT = "1cv8.exe"; //$NON-NLS-1$
+
+    /**
+     * The client to launch: the thin one beside the configured executable when it is there.
+     * <p>
+     * Measured on an infobase the client could not open, because EDT held the file: 1cv8.exe
+     * waits without showing anything and has to be killed at the deadline, while 1cv8c.exe
+     * reaches the login, says the file access mode is wrong and exits. A run that ends with a
+     * reason beats one that ends with a deadline.
+     * </p>
+     * <p>
+     * Vanessa drives a thin client either way - the TestClient block written above names
+     * ClientType Thin. A preference already pointing at the thin client is left alone.
+     * </p>
+     *
+     * @param configured what the preference names.
+     * @return the thin client beside it, or the configured one when there is none
+     */
+    static File theClientToLaunch(File configured)
+    {
+        if (configured == null || !EITHER_CLIENT.equalsIgnoreCase(configured.getName()))
+        {
+            return configured;
+        }
+        File beside = configured.getParentFile();
+        if (beside == null)
+        {
+            return configured;
+        }
+        File thin = new File(beside, THIN_CLIENT);
+        return thin.isFile() ? thin : configured;
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -161,6 +161,10 @@ public class VanessaTool implements IMcpTool
                 "Name of the 1C user the run signs in as. A base with users defined meets a " //$NON-NLS-1$
                     + "client that names none with a login window, and the run then waits out " //$NON-NLS-1$
                     + "its whole deadline. A password cannot be passed here.") //$NON-NLS-1$
+            .booleanProperty("testClient", //$NON-NLS-1$
+                "Name a test client in VAParams for the start step to launch (default false). " //$NON-NLS-1$
+                    + "Measured on one stand: with the block present Vanessa writes no report " //$NON-NLS-1$
+                    + "at all, for any scenario; without it the same scenarios play.") //$NON-NLS-1$
             .integerProperty("testClientPort", //$NON-NLS-1$
                 "Port the test client listens on (default 48010). Name another when a second " //$NON-NLS-1$
                     + "run or another EDT already holds it.") //$NON-NLS-1$
@@ -386,6 +390,8 @@ public class VanessaTool implements IMcpTool
                 + "a port is 1 to " + HIGHEST_PORT + ". Read as a number it cannot be, the " //$NON-NLS-1$ //$NON-NLS-2$
                 + "run would have started on the default port instead of the one named.").toJson(); //$NON-NLS-1$
         }
+        final boolean settledWantsTestClient =
+            JsonUtils.extractBooleanArgument(params, "testClient", false); //$NON-NLS-1$
         final int settledClientPort = namedPort != null ? namedPort.intValue() : TEST_CLIENT_PORT;
         String portRefusal = whyThePortCannotBeUsed(settledClientPort);
         if (portRefusal != null)
@@ -424,7 +430,8 @@ public class VanessaTool implements IMcpTool
             // cancel meant for that run destroy this client instead.
             return play(settledExe, settledEpf, settledConnection, settledFeature, composedScenario,
                 screenshots, keepOpen, stepDelay, settledTimeout, settledClientPort,
-                extraVaParams, runDirForJob, null, settledInfobase, settledAddress);
+                extraVaParams, runDirForJob, null, settledInfobase, settledAddress,
+                settledWantsTestClient);
         }
         PendingWorkRegistry registry = PendingWorkRegistry.VANESSA;
         registry.pruneExpired();
@@ -443,7 +450,7 @@ public class VanessaTool implements IMcpTool
                 () -> play(settledExe, settledEpf, settledConnection, settledFeature,
                     composedScenario, screenshots, keepOpen, stepDelay, settledTimeout,
                     settledClientPort, extraVaParams, runDirForJob, jobKey, settledInfobase,
-                    settledAddress));
+                    settledAddress, settledWantsTestClient));
         }
         String done = entry.await(ASYNC_FIRST_WAIT_MS);
         if (done != null)
@@ -485,12 +492,13 @@ public class VanessaTool implements IMcpTool
      *            when the caller named the connection string itself.
      * @param infobaseAddress the infobase EDT holds, as it was resolved once, or
      *            <code>null</code> when the caller named the connection string itself.
+     * @param withTestClient whether to name a test client for the start step to launch.
      * @return the answer
      */
     private String play(File exeFile, File epfFile, String connectionString, File featurePath,
         String composedScenario, boolean screenshots, boolean keepOpen, int stepDelay,
         int timeoutSec, int clientPort, JsonObject extraVaParams, File workingDir, String jobKey,
-        String infobaseName, InfobaseAddress.Address infobaseAddress)
+        String infobaseName, InfobaseAddress.Address infobaseAddress, boolean withTestClient)
     {
         String refused = refusedBeforeLaunch(jobKey);
         if (refused != null)
@@ -541,7 +549,8 @@ public class VanessaTool implements IMcpTool
             }
 
             String vaParamsJson = buildVaParams(playing, junitFile, shotsDir, screenshots,
-                keepOpen, stepDelay, connectionString, clientPort, timeoutSec, extraVaParams);
+                keepOpen, stepDelay, connectionString, clientPort, timeoutSec, withTestClient,
+                extraVaParams);
             writeUtf8Bom(paramsFile, vaParamsJson);
 
             File runDir = workingDir != null ? workingDir : outDir.toFile();
@@ -968,19 +977,27 @@ public class VanessaTool implements IMcpTool
      * @param clientPort the port the test client listens on.
      * @param clientTimeoutSec the whole budget of the run; the client share of it is taken by
      *            {@link #clientWaitWithin(int)}.
+     * @param withTestClient whether to name a test client for the start step to launch.
      * @param extra what the caller added to the Vanessa document, merged last.
      * @return the document, ready to be written
      */
     static String buildVaParams(File featurePath, File junitFile, File shotsDir,
         boolean screenshots, boolean keepOpen, int stepDelay, String connectionString,
-        int clientPort, int clientTimeoutSec, JsonObject extra)
+        int clientPort, int clientTimeoutSec, boolean withTestClient, JsonObject extra)
     {
         JsonObject o = new JsonObject();
+        // Measured on this stand: with the block present Vanessa writes no report at all, for
+        // any scenario, including one whose only step is a three second wait. Without it the
+        // same scenarios play and a failing step is reported by name. It is therefore off
+        // unless the caller asks for it.
         // The step that starts TestClient has no client to start without this block: the run
         // answers "Тип не определен (ТестируемаяГруппаФормы)" with an empty client type and PID 0,
         // because the UI-testing types exist only once a client runs under the test manager.
-        o.add("TestClient", //$NON-NLS-1$
-            testClient(connectionString, clientPort, clientWaitWithin(clientTimeoutSec)));
+        if (withTestClient)
+        {
+            o.add("TestClient", //$NON-NLS-1$
+                testClient(connectionString, clientPort, clientWaitWithin(clientTimeoutSec)));
+        }
         // Without this Vanessa opens its own window and waits there. Every run then spends its
         // whole time budget on a form nobody is looking at, ends killed, and writes no report -
         // which reads exactly like a scenario that never started.

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -26,6 +26,8 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import ru.aiedt.mcp.server.Activator;
 import ru.aiedt.mcp.server.settings.PrefKeys;
+import ru.aiedt.mcp.server.support.InfobaseAddress;
+import ru.aiedt.mcp.server.support.ProjectResolver;
 import ru.aiedt.mcp.server.wire.SchemaComposer;
 import ru.aiedt.mcp.server.wire.JsonUtils;
 import ru.aiedt.mcp.server.wire.ToolResult;
@@ -85,7 +87,8 @@ public class VanessaTool implements IMcpTool
             + "running infobase and reports which scenario step failed and why (+ failure " //$NON-NLS-1$
             + "screenshots). Complements yaxunit_tests (code from the inside) by driving the UI " //$NON-NLS-1$
             + "from the outside. Pass featurePath (a .feature file or a directory of them) and " //$NON-NLS-1$
-            + "connectionString (the 1C infobase connection string, e.g. File=...; or Srvr=...;Ref=...). " //$NON-NLS-1$
+            + "projectName - the infobase the project is bound to is the one played against, " //$NON-NLS-1$
+            + "or connectionString to name another. " //$NON-NLS-1$
             + "Requires vanessa-automation.epf and the 1C thick client (1cv8.exe) configured in EDT " //$NON-NLS-1$
             + "preferences (download from github.com/Pr-Mex/vanessa-automation). Waits for the run " //$NON-NLS-1$
             + "and answers when it ends; async=true answers with a runKey instead, which comes " //$NON-NLS-1$
@@ -122,12 +125,14 @@ public class VanessaTool implements IMcpTool
                 "The step that gets a client to work in. Defaults to launching TestClient or " //$NON-NLS-1$
                     + "attaching to one already running.") //$NON-NLS-1$
             .stringProperty("connectionString", //$NON-NLS-1$
-                "1C infobase connection string (required), e.g. 'File=\"C:\\\\ib\";' or " //$NON-NLS-1$
-                    + "'Srvr=\"host\";Ref=\"base\";'. A Pwd is refused: it would reach the " //$NON-NLS-1$
+                "1C infobase connection string, e.g. 'File=\"C:\\\\ib\";' or " //$NON-NLS-1$
+                    + "'Srvr=\"host\";Ref=\"base\";'. Omitted, the infobase the named project is " //$NON-NLS-1$
+                    + "bound to is used - EDT knows it already. A server infobase has to be named " //$NON-NLS-1$
+                    + "here. A Pwd is refused: it would reach the " //$NON-NLS-1$
                     + "client as a command-line argument, readable by every process on the machine. " //$NON-NLS-1$
                     + "Use an infobase that needs no password, or one that accepts the operating " //$NON-NLS-1$
-                    + "system's authentication. Required to start a run; a call that carries a " //$NON-NLS-1$
-                    + "runKey does not take it.") //$NON-NLS-1$
+                    + "system's authentication. A call that carries a runKey does not take " //$NON-NLS-1$
+                    + "it.") //$NON-NLS-1$
             .booleanProperty("async", //$NON-NLS-1$
                 "Hand back a runKey instead of waiting out the run. Come back with that runKey " //$NON-NLS-1$
                     + "for the result, or with runKey and cancel=true to stop the client.") //$NON-NLS-1$
@@ -265,10 +270,27 @@ public class VanessaTool implements IMcpTool
         }
 
         String connectionString = JsonUtils.extractStringArgument(params, "connectionString"); //$NON-NLS-1$
+        String infobaseFrom = null;
         if (connectionString == null || connectionString.trim().isEmpty())
         {
-            return ToolResult.error("connectionString is required (the 1C infobase connection " //$NON-NLS-1$
-                + "string, e.g. File=\"C:\\ib\"; ).").toJson(); //$NON-NLS-1$
+            // The caller has EDT open, and EDT already knows which infobase the project belongs to
+            // - it is the one update_database writes into. Making them type it again is asking for
+            // what the environment holds, and a typed string can name a different infobase.
+            String projectForInfobase = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
+            IProject project = projectForInfobase == null || projectForInfobase.trim().isEmpty()
+                ? null : ProjectResolver.resolve(projectForInfobase);
+            connectionString = InfobaseAddress.ofProject(project);
+            if (connectionString != null)
+            {
+                infobaseFrom = InfobaseAddress.nameOfProjectInfobase(project);
+            }
+        }
+        if (connectionString == null || connectionString.trim().isEmpty())
+        {
+            return ToolResult.error("The infobase is not named. Pass projectName and the " //$NON-NLS-1$
+                + "infobase the project is bound to is used, or connectionString to name one " //$NON-NLS-1$
+                + "directly. A project with no infobase application, or one bound to a server " //$NON-NLS-1$
+                + "infobase, has to be named directly.").toJson(); //$NON-NLS-1$
         }
         String secretRefusal = whyASecretCannotBePassed(connectionString);
         if (secretRefusal != null)
@@ -327,6 +349,8 @@ public class VanessaTool implements IMcpTool
             }
         }
         final String composedScenario = hasText ? scenarioText : null;
+        final String settledInfobase = infobaseFrom;
+        final String settledConnection = connectionString;
 
         boolean screenshots = JsonUtils.extractBooleanArgument(params, "screenshots", true); //$NON-NLS-1$
         boolean keepOpen = JsonUtils.extractBooleanArgument(params, "keepOpen", false); //$NON-NLS-1$
@@ -362,9 +386,9 @@ public class VanessaTool implements IMcpTool
             // No key: the caller is holding the connection and is never handed one, and an async
             // run with these same arguments owns this key. Registering both under it would let a
             // cancel meant for that run destroy this client instead.
-            return play(settledExe, settledEpf, connectionString, settledFeature, composedScenario,
+            return play(settledExe, settledEpf, settledConnection, settledFeature, composedScenario,
                 screenshots, keepOpen, stepDelay, settledTimeout, extraVaParams, runDirForJob,
-                null);
+                null, settledInfobase);
         }
         PendingWorkRegistry registry = PendingWorkRegistry.VANESSA;
         registry.pruneExpired();
@@ -380,9 +404,9 @@ public class VanessaTool implements IMcpTool
                 return ToolResult.error(alreadyGoing(going)).toJson();
             }
             entry = registry.getOrStart(jobKey,
-                () -> play(settledExe, settledEpf, connectionString, settledFeature,
+                () -> play(settledExe, settledEpf, settledConnection, settledFeature,
                     composedScenario, screenshots, keepOpen, stepDelay, settledTimeout,
-                    extraVaParams, runDirForJob, jobKey));
+                    extraVaParams, runDirForJob, jobKey, settledInfobase));
         }
         String done = entry.await(ASYNC_FIRST_WAIT_MS);
         if (done != null)
@@ -419,11 +443,14 @@ public class VanessaTool implements IMcpTool
      * @param extraVaParams what the caller added to the Vanessa document.
      * @param workingDir where to run.
      * @param jobKey the key this run is cancelled by.
+     * @param infobaseName the infobase this resolved from the project, or <code>null</code>
+     *            when the caller named the connection string itself.
      * @return the answer
      */
     private String play(File exeFile, File epfFile, String connectionString, File featurePath,
         String composedScenario, boolean screenshots, boolean keepOpen, int stepDelay,
-        int timeoutSec, JsonObject extraVaParams, File workingDir, String jobKey)
+        int timeoutSec, JsonObject extraVaParams, File workingDir, String jobKey,
+        String infobaseName)
     {
         String refused = refusedBeforeLaunch(jobKey);
         if (refused != null)
@@ -545,6 +572,9 @@ public class VanessaTool implements IMcpTool
 
             ToolResult ok = ToolResult.success()
                 .put("operation", NAME) //$NON-NLS-1$
+                // Named when this worked it out from the project rather than being told: a run
+                // against the wrong infobase looks exactly like a run against the right one.
+                .put("infobase", infobaseName) //$NON-NLS-1$
                 .put("passed", results.isPassed()) //$NON-NLS-1$
                 .put("summary", summary) //$NON-NLS-1$
                 .put("total", results.getTotal()) //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -108,6 +108,19 @@ public class VanessaTool implements IMcpTool
                     + "step wording is Vanessa's own and differs between its versions, so it is " //$NON-NLS-1$
                     + "yours to give, the same way the vanessaParams names are. Given together " //$NON-NLS-1$
                     + "with featurePath, both are refused.") //$NON-NLS-1$
+            .stringProperty("formToOpen", //$NON-NLS-1$
+                "The form to open and photograph, in the words the opening step expects - a " //$NON-NLS-1$
+                    + "common form's name, a catalog's FQN, whatever the step takes. The scenario " //$NON-NLS-1$
+                    + "is composed from it, so neither featurePath nor scenarioText is passed " //$NON-NLS-1$
+                    + "with it. The snapshot arrives among the run's screenshots.") //$NON-NLS-1$
+            .stringProperty("openStep", //$NON-NLS-1$
+                "The step that opens the form, with {form} where the name goes. Defaults to " //$NON-NLS-1$
+                    + "opening a common form. A list form, an object form and an extension's " //$NON-NLS-1$
+                    + "form are opened by different words, and the words belong to Vanessa and " //$NON-NLS-1$
+                    + "differ between its versions, so pass the one your library uses.") //$NON-NLS-1$
+            .stringProperty("startStep", //$NON-NLS-1$
+                "The step that gets a client to work in. Defaults to launching TestClient or " //$NON-NLS-1$
+                    + "attaching to one already running.") //$NON-NLS-1$
             .stringProperty("connectionString", //$NON-NLS-1$
                 "1C infobase connection string (required), e.g. 'File=\"C:\\\\ib\";' or " //$NON-NLS-1$
                     + "'Srvr=\"host\";Ref=\"base\";'. A Pwd is refused: it would reach the " //$NON-NLS-1$
@@ -271,12 +284,21 @@ public class VanessaTool implements IMcpTool
         }
         String featurePathArg = JsonUtils.extractStringArgument(params, "featurePath"); //$NON-NLS-1$
         String scenarioText = JsonUtils.extractStringArgument(params, "scenarioText"); //$NON-NLS-1$
+        String formToOpen = JsonUtils.extractStringArgument(params, "formToOpen"); //$NON-NLS-1$
         boolean hasPath = featurePathArg != null && !featurePathArg.trim().isEmpty();
         boolean hasText = scenarioText != null && !scenarioText.trim().isEmpty();
-        String badlyNamed = whyTheScenarioIsNotNamed(hasPath, hasText);
+        boolean hasForm = formToOpen != null && !formToOpen.trim().isEmpty();
+        String badlyNamed = whyTheScenarioIsNotNamed(hasPath, hasText, hasForm);
         if (badlyNamed != null)
         {
             return ToolResult.error(badlyNamed).toJson();
+        }
+        if (hasForm)
+        {
+            scenarioText = scenarioForForm(formToOpen.trim(),
+                JsonUtils.extractStringArgument(params, "startStep"), //$NON-NLS-1$
+                JsonUtils.extractStringArgument(params, "openStep")); //$NON-NLS-1$
+            hasText = true;
         }
 
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
@@ -579,18 +601,72 @@ public class VanessaTool implements IMcpTool
      */
     static String whyTheScenarioIsNotNamed(boolean hasPath, boolean hasText)
     {
-        if (hasPath && hasText)
+        return whyTheScenarioIsNotNamed(hasPath, hasText, false);
+    }
+
+    /**
+     * Why this call does not say what to play, or <code>null</code> when it does.
+     *
+     * @param hasPath whether a file or directory was named.
+     * @param hasText whether the scenario itself was given.
+     * @param hasForm whether a form to open was named, from which a scenario is composed.
+     * @return the refusal, or <code>null</code>
+     */
+    static String whyTheScenarioIsNotNamed(boolean hasPath, boolean hasText, boolean hasForm)
+    {
+        int named = (hasPath ? 1 : 0) + (hasText ? 1 : 0) + (hasForm ? 1 : 0);
+        if (named > 1)
         {
-            return "featurePath and scenarioText both name what to play, and only one of them " //$NON-NLS-1$
-                + "can be it. Pass the path to a file that exists, or the scenario text to be " //$NON-NLS-1$
-                + "written for this run."; //$NON-NLS-1$
+            return "featurePath, scenarioText and formToOpen each name what to play, and only " //$NON-NLS-1$
+                + "one of them can be it. Pass the path to a file that exists, the scenario text " //$NON-NLS-1$
+                + "to be written for this run, or the form to open and snapshot."; //$NON-NLS-1$
         }
-        if (!hasPath && !hasText)
+        if (named == 0)
         {
             return "featurePath is required (a .feature file or a directory), or scenarioText " //$NON-NLS-1$
-                + "with the scenario itself."; //$NON-NLS-1$
+                + "with the scenario itself, or formToOpen with the form to open and snapshot."; //$NON-NLS-1$
         }
         return null;
+    }
+
+    /** How the scenario opens a form when the caller does not say otherwise. */
+    static final String OPEN_STEP = "Я открываю общую форму \"{form}\""; //$NON-NLS-1$
+
+    /** How the scenario gets a client to work in when the caller does not say otherwise. */
+    static final String START_STEP =
+        "Я запускаю сценарий открытия TestClient или подключаю уже существующий"; //$NON-NLS-1$
+
+    /**
+     * A scenario that opens one form and has it photographed.
+     * <p>
+     * The snapshot is not a step. Vanessa takes one before and after the step that follows the
+     * {@code @screenshot} tag, writing them where {@code КаталогСохраненияСкриншотов} points - which
+     * this tool already sets for every run, and which the report reader already groups by step.
+     * </p>
+     * <p>
+     * Both step wordings are arguments with a default rather than text built into this file. They
+     * belong to Vanessa and differ between its versions and between kinds of form: a list form and
+     * an object form are opened by different words, and one wording nailed down here would fit one
+     * of them. The same reasoning gave {@code vanessaParams} its open shape.
+     * </p>
+     *
+     * @param form what to put where the wording says {@code {form}}.
+     * @param startStep how to get a client, or <code>null</code> for {@link #START_STEP}.
+     * @param openStep how to open the form, or <code>null</code> for {@link #OPEN_STEP}.
+     * @return the scenario text
+     */
+    static String scenarioForForm(String form, String startStep, String openStep)
+    {
+        String opening = openStep == null || openStep.trim().isEmpty() ? OPEN_STEP : openStep;
+        String starting = startStep == null || startStep.trim().isEmpty() ? START_STEP : startStep;
+        return "#language: ru\n\n" //$NON-NLS-1$
+            + "Функционал: Снимок формы\n\n" //$NON-NLS-1$
+            + "Контекст:\n" //$NON-NLS-1$
+            + "    Дано " + starting + "\n\n" //$NON-NLS-1$ //$NON-NLS-2$
+            + "Сценарий: Снимок формы " + form + "\n" //$NON-NLS-1$ //$NON-NLS-2$
+            + "    @screenshot\n" //$NON-NLS-1$
+            + "    Когда " + opening.replace("{form}", form) + "\n" //$NON-NLS-1$ //$NON-NLS-2$
+            + "    И Я закрываю все окна клиентского приложения\n"; //$NON-NLS-1$
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -26,7 +26,10 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import ru.aiedt.mcp.server.Activator;
 import ru.aiedt.mcp.server.settings.PrefKeys;
+import ru.aiedt.mcp.server.support.ErrorTags;
 import ru.aiedt.mcp.server.support.InfobaseAddress;
+import ru.aiedt.mcp.server.support.InfobaseIdentity;
+import ru.aiedt.mcp.server.support.MonopolyLock;
 import ru.aiedt.mcp.server.support.ProjectResolver;
 import ru.aiedt.mcp.server.wire.SchemaComposer;
 import ru.aiedt.mcp.server.wire.JsonUtils;
@@ -274,6 +277,7 @@ public class VanessaTool implements IMcpTool
 
         String connectionString = JsonUtils.extractStringArgument(params, "connectionString"); //$NON-NLS-1$
         String infobaseFrom = null;
+        InfobaseAddress.Address infobaseAddress = null;
         if (connectionString == null || connectionString.trim().isEmpty())
         {
             // The caller has EDT open, and EDT already knows which infobase the project belongs to
@@ -287,6 +291,7 @@ public class VanessaTool implements IMcpTool
             {
                 connectionString = address.connectionString();
                 infobaseFrom = address.name();
+                infobaseAddress = address;
             }
         }
         if (connectionString == null || connectionString.trim().isEmpty())
@@ -358,6 +363,7 @@ public class VanessaTool implements IMcpTool
             }
         }
         final String composedScenario = hasText ? scenarioText : null;
+        final InfobaseAddress.Address settledAddress = infobaseAddress;
         final String settledInfobase = infobaseFrom;
         final String settledConnection = connectionString;
 
@@ -410,7 +416,7 @@ public class VanessaTool implements IMcpTool
             // cancel meant for that run destroy this client instead.
             return play(settledExe, settledEpf, settledConnection, settledFeature, composedScenario,
                 screenshots, keepOpen, stepDelay, settledTimeout, settledClientPort,
-                extraVaParams, runDirForJob, null, settledInfobase);
+                extraVaParams, runDirForJob, null, settledInfobase, settledAddress);
         }
         PendingWorkRegistry registry = PendingWorkRegistry.VANESSA;
         registry.pruneExpired();
@@ -428,7 +434,8 @@ public class VanessaTool implements IMcpTool
             entry = registry.getOrStart(jobKey,
                 () -> play(settledExe, settledEpf, settledConnection, settledFeature,
                     composedScenario, screenshots, keepOpen, stepDelay, settledTimeout,
-                    settledClientPort, extraVaParams, runDirForJob, jobKey, settledInfobase));
+                    settledClientPort, extraVaParams, runDirForJob, jobKey, settledInfobase,
+                    settledAddress));
         }
         String done = entry.await(ASYNC_FIRST_WAIT_MS);
         if (done != null)
@@ -468,12 +475,14 @@ public class VanessaTool implements IMcpTool
      * @param jobKey the key this run is cancelled by.
      * @param infobaseName the infobase this resolved from the project, or <code>null</code>
      *            when the caller named the connection string itself.
+     * @param infobaseAddress the infobase EDT holds, as it was resolved once, or
+     *            <code>null</code> when the caller named the connection string itself.
      * @return the answer
      */
     private String play(File exeFile, File epfFile, String connectionString, File featurePath,
         String composedScenario, boolean screenshots, boolean keepOpen, int stepDelay,
         int timeoutSec, int clientPort, JsonObject extraVaParams, File workingDir, String jobKey,
-        String infobaseName)
+        String infobaseName, InfobaseAddress.Address infobaseAddress)
     {
         String refused = refusedBeforeLaunch(jobKey);
         if (refused != null)
@@ -533,7 +542,29 @@ public class VanessaTool implements IMcpTool
             Activator.logInfo("vanessa: launching " + redactSecrets(String.join(" ", command)) //$NON-NLS-1$ //$NON-NLS-2$
                 + "\nVAParams.json keys: " + keysOf(vaParamsJson)); //$NON-NLS-1$
 
-            ProcessResult pr = runVanessa(command, runDir, timeoutSec, jobKey, clientLaunched);
+            ProcessResult pr;
+            String heldBack = null;
+            // A file infobase admits one owner. While EDT holds it, the client starts and never
+            // connects: the process lives out its whole deadline without one event reaching the
+            // infobase log, and the answer reads as a run that timed out rather than one that
+            // never began. The claim keeps the other thick-client operations out of an infobase
+            // that is standing released.
+            String subject = infobaseAddress == null || infobaseAddress.infobase() == null
+                ? null : InfobaseIdentity.of(infobaseAddress.infobase());
+            try (MonopolyLock.Claim claim = subject == null ? null
+                : MonopolyLock.claim(subject, "vanessa")) //$NON-NLS-1$
+            {
+                if (claim != null && !claim.granted())
+                {
+                    return ToolResult.error(claim.refusal())
+                        .put("failureKind", ErrorTags.BUSY.wire()).toJson(); //$NON-NLS-1$
+                }
+                try (InfobaseAddress.Hold hold = InfobaseAddress.release(infobaseAddress))
+                {
+                    heldBack = hold.why();
+                    pr = runVanessa(command, runDir, timeoutSec, jobKey, clientLaunched);
+                }
+            }
             // Removed here rather than in the finally: every answer below is built before a
             // finally runs, and the paths that need this most are the ones that go wrong.
             leftBehind = removeComposed(composedFile);
@@ -561,8 +592,12 @@ public class VanessaTool implements IMcpTool
                     return ToolResult.error("Vanessa run timed out after " + timeoutSec + "s" //$NON-NLS-1$ //$NON-NLS-2$
                         + (keepOpen ? " (keepOpen=true keeps 1C open, so it never exits - set keepOpen=false)." //$NON-NLS-1$
                             : ". Raise timeoutSeconds, or the run may be stuck on a 1C login/update dialog.") //$NON-NLS-1$
+                        // Named before the deadline is blamed: a client that never got the
+                        // infobase spends the whole deadline and looks exactly like a slow run.
+                        + (heldBack == null ? "" : " " + heldBack + ".") //$NON-NLS-1$ //$NON-NLS-2$
                         + " " + tail(pr.output))
-                        .put("composedScenarioLeftBehind", leftBehind).toJson(); //$NON-NLS-1$
+                        .put("composedScenarioLeftBehind", leftBehind) //$NON-NLS-1$
+                        .put("infobaseNotReleased", heldBack).toJson(); //$NON-NLS-1$
                 }
                 String incomplete = whatTheDistributionIsMissing(epfFile);
                 return ToolResult.error("Vanessa produced no JUnit report (exit " + pr.exitCode //$NON-NLS-1$
@@ -1653,6 +1688,10 @@ public class VanessaTool implements IMcpTool
         }
         finally
         {
+            // Whatever ended this - a finish, a deadline, a cancel, an interrupt - the client is
+            // gone before the caller takes the infobase back. EDT reconnecting while a client
+            // still has the file open is the state the release exists to avoid.
+            stopAndAwait(proc);
             // However this ended - finished, timed out, or cancelled from another call - the
             // handle goes. Leaving it would let a later cancel destroy a process that is no longer
             // this run, because the operating system gives the number back.
@@ -1660,6 +1699,37 @@ public class VanessaTool implements IMcpTool
             {
                 RUNNING.remove(runKey, proc);
             }
+        }
+    }
+
+    /** Seconds to wait for a stopped client to actually be gone. */
+    private static final int PROCESS_DEATH_WAIT_SEC = 20;
+
+    /**
+     * Stops the client and waits for it to be gone.
+     * <p>
+     * {@code destroyForcibly} only asks. The process is still there until the operating system
+     * says otherwise, and a caller that takes the infobase back on the strength of the ask alone
+     * hands EDT a file another process still has open.
+     * </p>
+     *
+     * @param proc the client.
+     */
+    private static void stopAndAwait(Process proc)
+    {
+        if (!proc.isAlive())
+        {
+            return;
+        }
+        proc.descendants().forEach(ProcessHandle::destroyForcibly);
+        proc.destroyForcibly();
+        try
+        {
+            proc.waitFor(PROCESS_DEATH_WAIT_SEC, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException interrupted)
+        {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -157,6 +157,10 @@ public class VanessaTool implements IMcpTool
                     + "working directory.") //$NON-NLS-1$
             .integerProperty("timeoutSeconds", //$NON-NLS-1$
                 "Max seconds to wait for the run (default 300, max 3600).") //$NON-NLS-1$
+            .stringProperty("infobaseUser", //$NON-NLS-1$
+                "Name of the 1C user the run signs in as. A base with users defined meets a " //$NON-NLS-1$
+                    + "client that names none with a login window, and the run then waits out " //$NON-NLS-1$
+                    + "its whole deadline. A password cannot be passed here.") //$NON-NLS-1$
             .integerProperty("testClientPort", //$NON-NLS-1$
                 "Port the test client listens on (default 48010). Name another when a second " //$NON-NLS-1$
                     + "run or another EDT already holds it.") //$NON-NLS-1$
@@ -301,6 +305,10 @@ public class VanessaTool implements IMcpTool
                 + "directly. A project with no infobase application, or one bound to a server " //$NON-NLS-1$
                 + "infobase, has to be named directly.").toJson(); //$NON-NLS-1$
         }
+        // Appended to the string, not passed as /N: the test client the start step launches is
+        // given its own PathToInfobase, and a string carries the user into both.
+        connectionString = namingTheUser(connectionString,
+            JsonUtils.extractStringArgument(params, "infobaseUser")); //$NON-NLS-1$
         String secretRefusal = whyASecretCannotBePassed(connectionString);
         if (secretRefusal != null)
         {
@@ -864,6 +872,32 @@ public class VanessaTool implements IMcpTool
             + "    @screenshot\n" //$NON-NLS-1$
             + "    Когда " + opening.replace("{form}", form) + "\n" //$NON-NLS-1$ //$NON-NLS-2$
             + "    И Я закрываю все окна клиентского приложения\n"; //$NON-NLS-1$
+    }
+
+    /**
+     * The connection string with the user named in it.
+     * <p>
+     * In the string rather than as {@code /N}: the test client the start step launches is given
+     * its own {@code PathToInfobase}, and a string carries the user into both clients where the
+     * argument would reach only one.
+     * </p>
+     *
+     * @param connectionString the infobase.
+     * @param user the 1C user, or <code>null</code> when the caller named none.
+     * @return the string, unchanged when there is no user to name
+     */
+    static String namingTheUser(String connectionString, String user)
+    {
+        if (connectionString == null || user == null || user.trim().isEmpty())
+        {
+            return connectionString;
+        }
+        String said = connectionString.trim();
+        if (!said.endsWith(";")) //$NON-NLS-1$
+        {
+            said = said + ";"; //$NON-NLS-1$
+        }
+        return said + "Usr=\"" + user.trim() + "\";"; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import ru.aiedt.mcp.server.Activator;
 import ru.aiedt.mcp.server.settings.PrefKeys;
+import ru.aiedt.mcp.server.support.AllureResultReader;
 import ru.aiedt.mcp.server.support.ErrorTags;
 import ru.aiedt.mcp.server.support.InfobaseAddress;
 import ru.aiedt.mcp.server.support.InfobaseIdentity;
@@ -600,9 +601,11 @@ public class VanessaTool implements IMcpTool
             Activator.logInfo("vanessa: exit=" + pr.exitCode + " timedOut=" + pr.timedOut //$NON-NLS-1$ //$NON-NLS-2$
                 + " output:\n" + redactSecrets(pr.output)); //$NON-NLS-1$
 
-            // A kept-open (or slow) run may have written the JUnit report before the process
-            // was killed on timeout - prefer a real report over a bare timeout error.
-            if (!junitFile.isFile())
+            // A kept-open (or slow) run may have written the report before the process was
+            // killed on timeout - prefer a real report over a bare timeout error.
+            File resultDir = junitFile.getAbsoluteFile().getParentFile();
+            boolean vanessaReported = AllureResultReader.resultsIn(resultDir).length > 0;
+            if (!vanessaReported && !junitFile.isFile())
             {
                 if (pr.timedOut)
                 {
@@ -627,7 +630,8 @@ public class VanessaTool implements IMcpTool
                     .put("composedScenarioLeftBehind", leftBehind).toJson(); //$NON-NLS-1$
             }
 
-            JUnitRunOutcome results = JUnitXmlReader.parse(junitFile);
+            JUnitRunOutcome results = vanessaReported
+                ? AllureResultReader.parse(resultDir) : JUnitXmlReader.parse(junitFile);
             List<String> shots = collectScreenshots(shotsDir);
             java.util.Map<String, String> pathByName = new java.util.LinkedHashMap<>();
             for (String path : shots)
@@ -1010,8 +1014,13 @@ public class VanessaTool implements IMcpTool
         {
             o.addProperty("ФайлСценария", featurePath.getAbsolutePath()); //$NON-NLS-1$
         }
-        o.addProperty("СохранятьРезультатыВФорматеJUnit", true); //$NON-NLS-1$
-        o.addProperty("ПутьКФайлуРезультатовJUnit", junitFile.getAbsolutePath()); //$NON-NLS-1$
+        // Vanessa has no JUnit parameters of its own: its documented keys for a machine
+        // readable result are the Allure pair, and the xml it writes there is what a JUnit
+        // reader consumes. Asked under the names below, it writes nothing and reports nothing,
+        // which reads as a run that produced no result.
+        o.addProperty("ДелатьОтчетВФорматеАллюр", true); //$NON-NLS-1$
+        o.addProperty("КаталогOutputAllureБазовый", //$NON-NLS-1$
+            junitFile.getAbsoluteFile().getParentFile().getAbsolutePath());
         o.addProperty("ДелатьСкриншотПриОшибке", screenshots); //$NON-NLS-1$
         o.addProperty("КаталогСохраненияСкриншотов", shotsDir.getAbsolutePath()); //$NON-NLS-1$
         o.addProperty("ЗакрыватьTestClientПослеПрогона", !keepOpen); //$NON-NLS-1$
@@ -1751,6 +1760,42 @@ public class VanessaTool implements IMcpTool
                 RUNNING.remove(runKey, proc);
             }
         }
+    }
+
+    /**
+     * The result file of a run: the one this asked for, or the xml Vanessa wrote beside it.
+     * <p>
+     * Vanessa names the files it writes itself, so the run directory is searched when the
+     * expected name is not there. The newest is taken: a directory of this run holds only
+     * what this run put in it.
+     * </p>
+     *
+     * @param asked the file this run asked Vanessa for.
+     * @return that file when it exists, otherwise the newest xml beside it, otherwise the
+     *         file that was asked for
+     */
+    static File theResultOf(File asked)
+    {
+        if (asked == null || asked.isFile())
+        {
+            return asked;
+        }
+        File dir = asked.getAbsoluteFile().getParentFile();
+        File[] xml = dir == null ? null
+            : dir.listFiles((d, name) -> name.toLowerCase(Locale.ROOT).endsWith(".xml")); //$NON-NLS-1$
+        if (xml == null || xml.length == 0)
+        {
+            return asked;
+        }
+        File newest = xml[0];
+        for (File one : xml)
+        {
+            if (one.lastModified() > newest.lastModified())
+            {
+                newest = one;
+            }
+        }
+        return newest;
     }
 
     /** Seconds to wait for a stopped client to actually be gone. */

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/WhatVanessaActuallyWritesTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/WhatVanessaActuallyWritesTest.java
@@ -1,0 +1,123 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+/**
+ * Vanessa has no JUnit parameters of its own. Asked for a machine readable result through the
+ * documented Allure pair it writes one {@code <uuid>-result.json} per scenario and names the files
+ * itself, so a caller looking for a single file of its own naming reads a finished run as one that
+ * produced nothing.
+ */
+public class WhatVanessaActuallyWritesTest
+{
+    /** A scenario that failed on a step, as Vanessa writes it. */
+    private static final String FAILED_ONE = "{\"name\":\"Снимок формы X\",\"status\":\"failed\"," //$NON-NLS-1$
+        + "\"statusDetails\":{\"message\":\"Тип не определен\",\"trace\":\"...\"}," //$NON-NLS-1$
+        + "\"steps\":[{\"name\":\"Когда Я открываю форму\",\"status\":\"skipped\"}]}"; //$NON-NLS-1$
+
+    /** A scenario that passed. */
+    private static final String PASSED_ONE = "{\"name\":\"Проба\",\"status\":\"passed\"}"; //$NON-NLS-1$
+
+    /** A scenario that stopped on an error rather than an assertion. */
+    private static final String BROKEN_ONE = "{\"name\":\"Сломанный\",\"status\":\"broken\"," //$NON-NLS-1$
+        + "\"statusDetails\":{\"message\":\"нет соединения\"}}"; //$NON-NLS-1$
+
+    /**
+     * Every scenario of the run is counted, and a failure keeps the message the platform gave -
+     * that message is the only thing that says why the run did not do what was asked.
+     *
+     * @throws IOException if the temporary run directory cannot be written
+     */
+    @Test
+    public void everyScenarioIsCountedAndTheReasonSurvives() throws IOException
+    {
+        File dir = Files.createTempDirectory("aiedt-va").toFile(); //$NON-NLS-1$
+        try
+        {
+            write(dir, "a" + AllureResultReader.RESULT_SUFFIX, FAILED_ONE); //$NON-NLS-1$
+            write(dir, "b" + AllureResultReader.RESULT_SUFFIX, PASSED_ONE); //$NON-NLS-1$
+            write(dir, "c" + AllureResultReader.RESULT_SUFFIX, BROKEN_ONE); //$NON-NLS-1$
+            write(dir, "d-container.json", "{\"name\":\"не результат\"}"); //$NON-NLS-1$ //$NON-NLS-2$
+
+            JUnitRunOutcome outcome = AllureResultReader.parse(dir);
+            assertEquals(3, outcome.getTotal());
+            assertEquals(1, outcome.getFailures());
+            assertEquals(1, outcome.getErrors());
+            assertEquals(1, outcome.getFailureDetails().size());
+            assertEquals("Снимок формы X", outcome.getFailureDetails().get(0).name); //$NON-NLS-1$
+            assertEquals("Тип не определен", outcome.getFailureDetails().get(0).message); //$NON-NLS-1$
+            assertEquals("нет соединения", outcome.getErrorDetails().get(0).message); //$NON-NLS-1$
+        }
+        finally
+        {
+            remove(dir);
+        }
+    }
+
+    /**
+     * A directory Vanessa never wrote into reads as a run with no tests rather than as a failure
+     * of its own: the caller decides what an empty run means.
+     *
+     * @throws IOException if the temporary directory cannot be written
+     */
+    @Test
+    public void anEmptyDirectoryIsARunWithNoTests() throws IOException
+    {
+        File dir = Files.createTempDirectory("aiedt-va-empty").toFile(); //$NON-NLS-1$
+        try
+        {
+            assertEquals(0, AllureResultReader.resultsIn(dir).length);
+            assertEquals(0, AllureResultReader.parse(dir).getTotal());
+            assertEquals(0, AllureResultReader.resultsIn(null).length);
+        }
+        finally
+        {
+            remove(dir);
+        }
+    }
+
+    /**
+     * Writes one file of the run.
+     *
+     * @param dir the run directory.
+     * @param name the file name.
+     * @param body its content.
+     * @throws IOException if it cannot be written
+     */
+    private static void write(File dir, String name, String body) throws IOException
+    {
+        Files.write(new File(dir, name).toPath(), body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Removes the directory and what it holds.
+     *
+     * @param dir the directory.
+     */
+    private static void remove(File dir)
+    {
+        File[] kids = dir.listFiles();
+        if (kids != null)
+        {
+            for (File kid : kids)
+            {
+                assertTrue(kid.delete());
+            }
+        }
+        dir.delete();
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/WhoHoldsTheInfobaseTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/WhoHoldsTheInfobaseTest.java
@@ -1,0 +1,66 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * A file infobase admits one owner. While EDT holds the designer session on it, a client started
+ * against the same infobase does not connect: the process lives out its whole deadline without one
+ * event reaching the infobase log, and the answer reads as a run that timed out rather than one
+ * that never began. {@link InfobaseAddress#release} has EDT let go for the length of a launch.
+ */
+public class WhoHoldsTheInfobaseTest
+{
+    /**
+     * A caller who named the connection string itself has no project, and there is nothing to let
+     * go of. The hold is still handed back, so the launch site needs no branch of its own.
+     */
+    @Test
+    public void withoutAProjectThereIsNothingToRelease()
+    {
+        try (InfobaseAddress.Hold hold = InfobaseAddress.release(null))
+        {
+            assertNotNull(hold);
+            assertFalse(hold.released());
+        }
+    }
+
+    /**
+     * Closing a hold that released nothing takes nothing back. An infobase the user had
+     * disconnected themselves must stay disconnected: connecting it back would change what they
+     * set up, and it reaches this class as the same "not released by us" state.
+     */
+    @Test
+    public void aHoldThatReleasedNothingTakesNothingBack()
+    {
+        InfobaseAddress.Hold hold = InfobaseAddress.release(null);
+        assertFalse(hold.released());
+        hold.close();
+        hold.close();
+        assertFalse(hold.released());
+    }
+
+    /**
+     * An address that names no infobase releases nothing and says nothing: there was no hold to
+     * begin with, so there is no reason to pass back to the caller.
+     */
+    @Test
+    public void anAddressWithoutAnInfobaseReleasesNothing()
+    {
+        InfobaseAddress.Address nowhere = new InfobaseAddress.Address(null, null, null, null);
+        try (InfobaseAddress.Hold hold = InfobaseAddress.release(nowhere))
+        {
+            assertFalse(hold.released());
+            assertNull(hold.why());
+        }
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
@@ -109,6 +109,34 @@ public class AScenarioNeedsNoFileOnDiskTest
     }
 
     @Test
+    public void aFormNameThatWouldBreakTheStepIsRefused()
+    {
+        assertNotNull("a quote closes the step's own quotes and the scenario means something else", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("Спра\"вочник", null)); //$NON-NLS-1$
+        assertNotNull("a step is one line", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("Справочник\nТовары", null)); //$NON-NLS-1$
+        assertNotNull("an empty name opens nothing", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("   ", null)); //$NON-NLS-1$
+        assertNull("an ordinary name goes through", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("ИИА_Агент", null)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aWordingWithNowhereToPutTheNameIsRefused()
+    {
+        String why = VanessaTool.whyTheFormCannotBeNamed("ИИА_Агент", //$NON-NLS-1$
+            "Я открываю общую форму"); //$NON-NLS-1$
+
+        assertNotNull("a wording without {form} opens whatever it names, not what was asked", why); //$NON-NLS-1$
+        assertTrue("the refusal says what to put in it: " + why, why.contains("{form}")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("a wording spanning lines is not one step", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("ИИА_Агент", "Я открываю\nформу {form}")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertNotNull("the step that gets a client is one line too", //$NON-NLS-1$
+            VanessaTool.whyTheFormCannotBeNamed("ИИА_Агент", null, //$NON-NLS-1$
+                "Я подключаюсь\nи еще что-то")); //$NON-NLS-1$
+    }
+
+    @Test
     public void namingAFormAndSomethingElseIsRefused()
     {
         assertNotNull("a form and a file both say what to play", //$NON-NLS-1$

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
@@ -77,6 +77,52 @@ public class AScenarioNeedsNoFileOnDiskTest
     }
 
     @Test
+    public void aFormIsPhotographedByATagRatherThanAStep()
+    {
+        String scenario = VanessaTool.scenarioForForm("ИИА_Агент", null, null); //$NON-NLS-1$
+
+        assertTrue("the snapshot is a tag on the step that follows, not a step of its own: " //$NON-NLS-1$
+            + scenario, scenario.contains("@screenshot")); //$NON-NLS-1$
+        assertTrue("the tag stands before the step it photographs", //$NON-NLS-1$
+            scenario.indexOf("@screenshot") < scenario.indexOf("Я открываю")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("the form the caller named belongs in the step: " + scenario, //$NON-NLS-1$
+            scenario.contains("\"ИИА_Агент\"")); //$NON-NLS-1$
+        assertTrue("a scenario needs a client to work in", //$NON-NLS-1$
+            scenario.contains(VanessaTool.START_STEP));
+        assertTrue("Vanessa reads the language from the first line", //$NON-NLS-1$
+            scenario.startsWith("#language: ru")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void theWordingOfEachStepCanBeGivenByTheCaller()
+    {
+        String scenario = VanessaTool.scenarioForForm("Справочник.Товары", //$NON-NLS-1$
+            "Я подключаюсь к запущенному клиенту", //$NON-NLS-1$
+            "Я открываю форму списка справочника {form}"); //$NON-NLS-1$
+
+        assertTrue("a list form is opened by other words than a common form: " + scenario, //$NON-NLS-1$
+            scenario.contains("Я открываю форму списка справочника Справочник.Товары")); //$NON-NLS-1$
+        assertTrue("and the client is reached by the caller's words too", //$NON-NLS-1$
+            scenario.contains("Я подключаюсь к запущенному клиенту")); //$NON-NLS-1$
+        assertTrue("the default wording is gone when the caller gave one", //$NON-NLS-1$
+            !scenario.contains(VanessaTool.OPEN_STEP.replace("{form}", "Справочник.Товары"))); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void namingAFormAndSomethingElseIsRefused()
+    {
+        assertNotNull("a form and a file both say what to play", //$NON-NLS-1$
+            VanessaTool.whyTheScenarioIsNotNamed(true, false, true));
+        assertNotNull("a form and a text both say what to play", //$NON-NLS-1$
+            VanessaTool.whyTheScenarioIsNotNamed(false, true, true));
+        assertNull("a form on its own is one way of saying it", //$NON-NLS-1$
+            VanessaTool.whyTheScenarioIsNotNamed(false, false, true));
+        assertTrue("the refusal offers the form as a third way: " //$NON-NLS-1$
+            + VanessaTool.whyTheScenarioIsNotNamed(false, false, false),
+            VanessaTool.whyTheScenarioIsNotNamed(false, false, false).contains("formToOpen")); //$NON-NLS-1$
+    }
+
+    @Test
     public void aNamedFileIsPlayedAsItIs() throws Exception
     {
         File named = new File(dir.toFile(), "given.feature"); //$NON-NLS-1$

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AScenarioNeedsNoFileOnDiskTest.java
@@ -217,6 +217,48 @@ public class AScenarioNeedsNoFileOnDiskTest
     }
 
     @Test
+    public void anIncompleteDistributionIsNamedInsteadOfGuessedAt() throws Exception
+    {
+        File epf = new File(dir.toFile(), "vanessa-automation.epf"); //$NON-NLS-1$
+        Files.write(epf.toPath(), new byte[] { 1 });
+        Files.createDirectories(new File(dir.toFile(), "locales").toPath()); //$NON-NLS-1$
+
+        String missing = VanessaTool.whatTheDistributionIsMissing(epf);
+
+        assertNotNull("an empty locales and an absent lib is why the run produced nothing", //$NON-NLS-1$
+            missing);
+        assertTrue("both folders are named: " + missing, //$NON-NLS-1$
+            missing.contains("locales") && missing.contains("lib")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue("and the way out is named too: " + missing, //$NON-NLS-1$
+            missing.contains("single-file")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aCompleteDistributionIsNotComplainedAbout() throws Exception
+    {
+        File epf = new File(dir.toFile(), "vanessa-automation.epf"); //$NON-NLS-1$
+        Files.write(epf.toPath(), new byte[] { 1 });
+        for (String folder : new String[] { "locales", "lib" }) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            Files.createDirectories(new File(dir.toFile(), folder).toPath());
+            Files.write(new File(dir.toFile(), folder + "/x.epf").toPath(), new byte[] { 1 }); //$NON-NLS-1$
+        }
+
+        assertNull("nothing is missing, so nothing is said", //$NON-NLS-1$
+            VanessaTool.whatTheDistributionIsMissing(epf));
+    }
+
+    @Test
+    public void theSingleFileBuildNeedsNothingBesideIt() throws Exception
+    {
+        File epf = new File(dir.toFile(), "vanessa-automation-single.epf"); //$NON-NLS-1$
+        Files.write(epf.toPath(), new byte[] { 1 });
+
+        assertNull("the single-file build carries its companions inside, so an empty directory " //$NON-NLS-1$
+            + "beside it says nothing", VanessaTool.whatTheDistributionIsMissing(epf)); //$NON-NLS-1$
+    }
+
+    @Test
     public void aFileThatWouldNotGoIsNamedRatherThanForgotten() throws Exception
     {
         File composed = new File(dir.toFile(), "composed.feature"); //$NON-NLS-1$

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ASecretIsNotTakenAtAllTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ASecretIsNotTakenAtAllTest.java
@@ -176,19 +176,19 @@ public class ASecretIsNotTakenAtAllTest
     {
         String[] refusal = new String[1];
 
-        VanessaTool.extraParams("{\"ПутьКФайлуРезультатовJUnit\":\"C:\\elsewhere.xml\"}", //$NON-NLS-1$
+        VanessaTool.extraParams("{\"КаталогOutputAllureБазовый\":\"C:\\elsewhere.xml\"}", //$NON-NLS-1$
             refusal);
 
         assertNotNull("moving the report would leave the run reading nothing", refusal[0]); //$NON-NLS-1$
-        assertTrue(refusal[0], refusal[0].contains("ПутьКФайлуРезультатовJUnit")); //$NON-NLS-1$
+        assertTrue(refusal[0], refusal[0].contains("КаталогOutputAllureБазовый")); //$NON-NLS-1$
     }
 
     @Test
     public void everyParameterTheToolDependsOnIsProtected()
     {
-        for (String key : new String[] {"СохранятьРезультатыВФорматеJUnit", //$NON-NLS-1$
-            "ПутьКФайлуРезультатовJUnit", "КаталогСохраненияСкриншотов", //$NON-NLS-1$ //$NON-NLS-2$
-            "ЗакрыватьTestClientПослеПрогона", "ВыходИзПриложенияПослеЗапускаСценариев"}) //$NON-NLS-1$ //$NON-NLS-2$
+        for (String key : new String[] {"ДелатьОтчетВФорматеАллюр", //$NON-NLS-1$
+            "КаталогOutputAllureБазовый", "КаталогOutputСкриншоты", //$NON-NLS-1$ //$NON-NLS-2$
+            "ЗакрытьTestClientПослеЗапускаСценариев", "ЗавершитьРаботуСистемы"}) //$NON-NLS-1$ //$NON-NLS-2$
         {
             String[] refusal = new String[1];
             VanessaTool.extraParams("{\"" + key + "\":\"x\"}", refusal); //$NON-NLS-1$ //$NON-NLS-2$
@@ -247,7 +247,7 @@ public class ASecretIsNotTakenAtAllTest
         String[] refusal = new String[1];
 
         VanessaTool.extraParams(
-            "{\"x\":[{\"ПутьКФайлуРезультатовJUnit\":\"C:\\elsewhere.xml\"}]}", refusal); //$NON-NLS-1$
+            "{\"x\":[{\"КаталогOutputAllureБазовый\":\"C:\\elsewhere.xml\"}]}", refusal); //$NON-NLS-1$
 
         assertNotNull("the shape is refused, and with it what was hidden in it", refusal[0]); //$NON-NLS-1$
     }
@@ -269,7 +269,7 @@ public class ASecretIsNotTakenAtAllTest
     {
         String[] refusal = new String[1];
 
-        VanessaTool.extraParams("{\"путькфайлурезультатовjunit\":\"C:\\\\elsewhere.xml\"}", //$NON-NLS-1$
+        VanessaTool.extraParams("{\"каталогoutputallureбазовый\":\"C:\\\\elsewhere.xml\"}", //$NON-NLS-1$
             refusal);
 
         assertNotNull("comparing exactly let the same parameter through in another case", //$NON-NLS-1$
@@ -282,7 +282,7 @@ public class ASecretIsNotTakenAtAllTest
         // The merge happens last, so a parameter the caller set through an argument of this tool
         // would be silently overruled - and the answer would still describe the argument.
         for (String key : new String[] {"КаталогФич", "ФайлСценария", //$NON-NLS-1$ //$NON-NLS-2$
-            "ДелатьСкриншотПриОшибке", "ПаузаМеждуШагами", //$NON-NLS-1$ //$NON-NLS-2$
+            "ДелатьСкриншотПриВозникновенииОшибки", "ПаузаМеждуШагами", //$NON-NLS-1$ //$NON-NLS-2$
             // Turned off, the run waits in Vanessa's own window until it is killed.
             "ВыполнитьСценарии", //$NON-NLS-1$
             // The passthrough takes no object, so what it can pass here only breaks the block.

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ASecretIsNotTakenAtAllTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/ASecretIsNotTakenAtAllTest.java
@@ -282,7 +282,11 @@ public class ASecretIsNotTakenAtAllTest
         // The merge happens last, so a parameter the caller set through an argument of this tool
         // would be silently overruled - and the answer would still describe the argument.
         for (String key : new String[] {"КаталогФич", "ФайлСценария", //$NON-NLS-1$ //$NON-NLS-2$
-            "ДелатьСкриншотПриОшибке", "ПаузаМеждуШагами"}) //$NON-NLS-1$ //$NON-NLS-2$
+            "ДелатьСкриншотПриОшибке", "ПаузаМеждуШагами", //$NON-NLS-1$ //$NON-NLS-2$
+            // Turned off, the run waits in Vanessa's own window until it is killed.
+            "ВыполнитьСценарии", //$NON-NLS-1$
+            // The passthrough takes no object, so what it can pass here only breaks the block.
+            "TestClient"}) //$NON-NLS-1$
         {
             String[] refusal = new String[1];
             VanessaTool.extraParams("{\"" + key + "\":\"x\"}", refusal); //$NON-NLS-1$ //$NON-NLS-2$

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
@@ -1,0 +1,179 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * The step "Я запускаю сценарий открытия TestClient" starts the client named in the TestClient
+ * block of VAParams. With no block the step reaches Vanessa with nothing to start and answers
+ * "Тип не определен (ТестируемаяГруппаФормы)" with an empty client type and PID 0 - the
+ * UI-testing types exist only once a client runs under the test manager.
+ */
+public class TheClientTheStartStepLooksForTest
+{
+    private static final String CONNECTION = "File=\"C:/bases/demo\";"; //$NON-NLS-1$
+
+    private static final int PORT = 48123;
+
+    /** Under the ceiling, so this is the value the block must carry. */
+    private static final int BUDGET_SEC = 300;
+
+    /**
+     * The block names the infobase the run was given, so the client opens the base the scenario
+     * was written against rather than whichever one Vanessa was last pointed at.
+     */
+    @Test
+    public void theClientOpensTheInfobaseOfTheRun()
+    {
+        JsonObject client = onlyClient(params());
+        assertEquals(CONNECTION, client.get("PathToInfobase").getAsString()); //$NON-NLS-1$
+        assertEquals("Thin", client.get("ClientType").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("localhost", client.get("ComputerName").getAsString()); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(client.get("PortTestClient").getAsInt() > 0); //$NON-NLS-1$
+    }
+
+    /**
+     * Vanessa spells the parameter name with a capital I in the middle. Corrected to the spelling
+     * that reads right, the key is simply never read.
+     */
+    @Test
+    public void theOddlySpelledKeyKeepsItsSpelling()
+    {
+        assertTrue(onlyClient(params()).has("AddItionalParameters")); //$NON-NLS-1$
+    }
+
+    /**
+     * The deadline comes from the run's own budget rather than a constant, so raising
+     * timeoutSeconds for a slow first start actually reaches the step that waits - but it stays
+     * under that budget, so Vanessa reaches its own timeout and writes the report before this tool
+     * kills the process.
+     */
+    @Test
+    public void theClientIsGivenAWindowAndADeadlineUnderTheRunsOwn()
+    {
+        JsonObject block = params().getAsJsonObject("TestClient"); //$NON-NLS-1$
+        assertTrue(block.get("runtestclientwithmaximizedwindow").getAsBoolean()); //$NON-NLS-1$
+        int deadline = block.get("testclienttimeout").getAsInt(); //$NON-NLS-1$
+        assertEquals(VanessaTool.clientWaitWithin(BUDGET_SEC), deadline);
+        assertTrue("the client may not be waited for as long as the whole run", //$NON-NLS-1$
+            deadline < BUDGET_SEC);
+    }
+
+    /**
+     * Every budget keeps something back for Vanessa to write its report in, so the wait is always
+     * shorter than the run that contains it. A budget of one second is the single exception, and
+     * no allocation can do better with one second.
+     */
+    @Test
+    public void everyBudgetKeepsAReserveToReportIn()
+    {
+        for (int budget : new int[] {2, 3, 5, 30, 60, 61, 90, 180, 300, 660, 3600})
+        {
+            int wait = VanessaTool.clientWaitWithin(budget);
+            String said = "budget " + budget + " gave a wait of " + wait; //$NON-NLS-1$ //$NON-NLS-2$
+            assertTrue(said, wait > 0);
+            assertTrue(said, wait < budget);
+            assertTrue(said, wait <= VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC);
+        }
+        assertTrue(VanessaTool.clientWaitWithin(1) > 0);
+    }
+
+    /**
+     * A number that is not a port is refused by name. Written down as given, it would leave the
+     * client not listening and the start step failing for a reason naming neither the port nor
+     * this tool.
+     */
+    @Test
+    public void aNumberThatIsNotAPortIsRefused()
+    {
+        assertNull(VanessaTool.whyThePortCannotBeUsed(1));
+        assertNull(VanessaTool.whyThePortCannotBeUsed(VanessaTool.TEST_CLIENT_PORT));
+        assertNull(VanessaTool.whyThePortCannotBeUsed(VanessaTool.HIGHEST_PORT));
+        for (int notAPort : new int[] {0, -1, VanessaTool.HIGHEST_PORT + 1})
+        {
+            String refusal = VanessaTool.whyThePortCannotBeUsed(notAPort);
+            assertNotNull("a port of " + notAPort + " was accepted", refusal); //$NON-NLS-1$ //$NON-NLS-2$
+            assertTrue(refusal.contains(String.valueOf(notAPort)));
+        }
+    }
+
+    /**
+     * A budget longer than the ceiling does not become the wait: a client that has not come up
+     * within the ceiling is not coming, and a long suite would otherwise spend all of its time
+     * waiting for one that never will.
+     */
+    @Test
+    public void aLongBudgetDoesNotBecomeALongWaitForTheClient()
+    {
+        String json = VanessaTool.buildVaParams(new File("C:/run/one.feature"), //$NON-NLS-1$
+            new File("C:/run/junit.xml"), new File("C:/run/shots"), true, false, 0, //$NON-NLS-1$ //$NON-NLS-2$
+            CONNECTION, PORT, VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC * 6, null);
+        JsonObject block = JsonParser.parseString(json).getAsJsonObject()
+            .getAsJsonObject("TestClient"); //$NON-NLS-1$
+        assertEquals(VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC,
+            block.get("testclienttimeout").getAsInt()); //$NON-NLS-1$
+    }
+
+    /** The port is the one the caller named, so a second run can be given another. */
+    @Test
+    public void thePortIsTheOneTheCallerNamed()
+    {
+        assertEquals(PORT, onlyClient(params()).get("PortTestClient").getAsInt()); //$NON-NLS-1$
+    }
+
+    /**
+     * Turned off, Vanessa opens its own window and waits there: the run spends its whole
+     * budget on a form nobody is looking at and writes no report, which reads exactly like a
+     * scenario that never started.
+     */
+    @Test
+    public void theRunIsToldToPlayItsScenarios()
+    {
+        assertTrue(params().get("ВыполнитьСценарии").getAsBoolean()); //$NON-NLS-1$
+    }
+
+    /**
+     * The single client of the block.
+     *
+     * @param root the parsed VAParams.
+     * @return the one entry of datatestclients
+     */
+    private static JsonObject onlyClient(JsonObject root)
+    {
+        JsonObject block = root.getAsJsonObject("TestClient"); //$NON-NLS-1$
+        assertNotNull("VAParams carries no TestClient block", block); //$NON-NLS-1$
+        JsonArray clients = block.getAsJsonArray("datatestclients"); //$NON-NLS-1$
+        assertNotNull("the TestClient block names no client", clients); //$NON-NLS-1$
+        assertEquals(1, clients.size());
+        return clients.get(0).getAsJsonObject();
+    }
+
+    /**
+     * VAParams as the runner writes them.
+     *
+     * @return the parsed document
+     */
+    private static JsonObject params()
+    {
+        String json = VanessaTool.buildVaParams(new File("C:/run/one.feature"), //$NON-NLS-1$
+            new File("C:/run/junit.xml"), new File("C:/run/shots"), true, false, 0, //$NON-NLS-1$ //$NON-NLS-2$
+            CONNECTION, PORT, BUDGET_SEC, null);
+        return JsonParser.parseString(json).getAsJsonObject();
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
@@ -176,4 +176,32 @@ public class TheClientTheStartStepLooksForTest
             CONNECTION, PORT, BUDGET_SEC, null);
         return JsonParser.parseString(json).getAsJsonObject();
     }
+
+    /**
+     * A base with users defined meets a client that names none with a login window, and the run
+     * then waits out its whole deadline. The user goes into the connection string, so it reaches
+     * the test client the start step launches as well.
+     */
+    @Test
+    public void theUserGoesIntoTheConnectionString()
+    {
+        assertEquals(CONNECTION + "Usr=\"Админ\"" + ";", //$NON-NLS-1$ //$NON-NLS-2$
+            VanessaTool.namingTheUser(CONNECTION, "Админ")); //$NON-NLS-1$
+    }
+
+    /** A string that ends without one gets the separator the next field needs. */
+    @Test
+    public void aStringMissingItsSeparatorGetsOne()
+    {
+        assertEquals("File=\"C:/b\";Usr=\"A\";", //$NON-NLS-1$
+            VanessaTool.namingTheUser("File=\"C:/b\"", "A")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /** Named nobody, the string is handed back as it came. */
+    @Test
+    public void withoutAUserTheStringIsUntouched()
+    {
+        assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, null));
+        assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, "   ")); //$NON-NLS-1$
+    }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
@@ -123,7 +123,7 @@ public class TheClientTheStartStepLooksForTest
     {
         String json = VanessaTool.buildVaParams(new File("C:/run/one.feature"), //$NON-NLS-1$
             new File("C:/run/junit.xml"), new File("C:/run/shots"), true, false, 0, //$NON-NLS-1$ //$NON-NLS-2$
-            CONNECTION, PORT, VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC * 6, null);
+            CONNECTION, PORT, VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC * 6, true, null);
         JsonObject block = JsonParser.parseString(json).getAsJsonObject()
             .getAsJsonObject("TestClient"); //$NON-NLS-1$
         assertEquals(VanessaTool.TEST_CLIENT_WAIT_CEILING_SEC,
@@ -173,7 +173,7 @@ public class TheClientTheStartStepLooksForTest
     {
         String json = VanessaTool.buildVaParams(new File("C:/run/one.feature"), //$NON-NLS-1$
             new File("C:/run/junit.xml"), new File("C:/run/shots"), true, false, 0, //$NON-NLS-1$ //$NON-NLS-2$
-            CONNECTION, PORT, BUDGET_SEC, null);
+            CONNECTION, PORT, BUDGET_SEC, true, null);
         return JsonParser.parseString(json).getAsJsonObject();
     }
 
@@ -203,5 +203,19 @@ public class TheClientTheStartStepLooksForTest
     {
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, null));
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, "   ")); //$NON-NLS-1$
+    }
+
+    /**
+     * Off unless asked for. Measured on one stand: with the block present Vanessa writes no report
+     * at all, for any scenario, including one whose only step is a three second wait; without it
+     * the same scenarios play and a failing step is reported by name.
+     */
+    @Test
+    public void theBlockIsAbsentUnlessTheCallerAsksForIt()
+    {
+        String json = VanessaTool.buildVaParams(new File("C:/run/one.feature"), //$NON-NLS-1$
+            new File("C:/run/junit.xml"), new File("C:/run/shots"), true, false, 0, //$NON-NLS-1$ //$NON-NLS-2$
+            CONNECTION, PORT, BUDGET_SEC, false, null);
+        assertNull(JsonParser.parseString(json).getAsJsonObject().get("TestClient")); //$NON-NLS-1$
     }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
@@ -204,26 +204,4 @@ public class TheClientTheStartStepLooksForTest
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, null));
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, "   ")); //$NON-NLS-1$
     }
-
-    /**
-     * A preference naming the client that is both is read as the thin one when that sits beside
-     * it. Given an infobase it cannot open, the thin client says so and exits, while the other
-     * waits without a window until the deadline kills it.
-     */
-    @Test
-    public void theThinClientBesideTheConfiguredOneIsPreferred() throws Exception
-    {
-        File bin = java.nio.file.Files.createTempDirectory("aiedt-bin").toFile(); //$NON-NLS-1$
-        File either = new File(bin, "1cv8.exe"); //$NON-NLS-1$
-        File thin = new File(bin, "1cv8c.exe"); //$NON-NLS-1$
-        assertTrue(either.createNewFile());
-        assertEquals(either, VanessaTool.theClientToLaunch(either));
-        assertTrue(thin.createNewFile());
-        assertEquals(thin, VanessaTool.theClientToLaunch(either));
-        assertEquals(thin, VanessaTool.theClientToLaunch(thin));
-        assertNull(VanessaTool.theClientToLaunch(null));
-        thin.delete();
-        either.delete();
-        bin.delete();
-    }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/TheClientTheStartStepLooksForTest.java
@@ -204,4 +204,26 @@ public class TheClientTheStartStepLooksForTest
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, null));
         assertEquals(CONNECTION, VanessaTool.namingTheUser(CONNECTION, "   ")); //$NON-NLS-1$
     }
+
+    /**
+     * A preference naming the client that is both is read as the thin one when that sits beside
+     * it. Given an infobase it cannot open, the thin client says so and exits, while the other
+     * waits without a window until the deadline kills it.
+     */
+    @Test
+    public void theThinClientBesideTheConfiguredOneIsPreferred() throws Exception
+    {
+        File bin = java.nio.file.Files.createTempDirectory("aiedt-bin").toFile(); //$NON-NLS-1$
+        File either = new File(bin, "1cv8.exe"); //$NON-NLS-1$
+        File thin = new File(bin, "1cv8c.exe"); //$NON-NLS-1$
+        assertTrue(either.createNewFile());
+        assertEquals(either, VanessaTool.theClientToLaunch(either));
+        assertTrue(thin.createNewFile());
+        assertEquals(thin, VanessaTool.theClientToLaunch(either));
+        assertEquals(thin, VanessaTool.theClientToLaunch(thin));
+        assertNull(VanessaTool.theClientToLaunch(null));
+        thin.delete();
+        either.delete();
+        bin.delete();
+    }
 }


### PR DESCRIPTION
## Photograph a form in a running 1C

`vanessa` takes a snapshot of a named form: it composes the scenario, starts the client, reads the
run and hands back the images.

## What was in the way

Four groups of parameters this tool wrote named nothing Vanessa reads, and it ignored each without
a word:

| Written | Read by Vanessa |
|---|---|
| `СохранятьРезультатыВФорматеJUnit`, `ПутьКФайлуРезультатовJUnit` | `ДелатьОтчетВФорматеАллюр`, `КаталогOutputAllureБазовый` |
| `ДелатьСкриншотПриОшибке`, `КаталогСохраненияСкриншотов` | `ДелатьСкриншотПриВозникновенииОшибки`, `КаталогOutputСкриншоты` |
| `ЗакрыватьTestClientПослеПрогона`, `ВыходИзПриложенияПослеЗапускаСценариев` | `ЗакрытьTestClientПослеЗапускаСценариев`, `ЗавершитьРаботуСистемы` |
| `ФайлСценария`, `ПаузаМеждуШагами` | no such keys |

So no run reported its outcome, no screenshot was written, and `keepOpen` decided nothing: the
client and the test client it started stayed open whatever was asked, while the answer described a
deadline. All eleven keys were reconciled against the documented set.

## What is new

- `AllureResultReader` reads the `<uuid>-result.json` files Vanessa names itself into the outcome
  the rest of the plugin reports on.
- `testManager` starts the client with `/TESTMANAGER`. The UI-testing types a form-driving scenario
  needs exist only there; without it such a step answers `Тип не определен (ТестируемаяГруппаФормы)`.
- `testClient` names a test client for the start step to launch.
- `testClientPort` names its port, refusing a number that is not one.
- `infobaseUser` names the 1C user; a password is refused as before.
- `InfobaseAddress.release` has EDT let go of the infobase for the length of a launch and take it
  back only when it was the one that let go. The run takes `MonopolyLock` on that infobase, and the
  client is gone before the infobase returns.
- The report names a release that did not happen instead of blaming the deadline.

## Measured

One run against a stand: `passed=true`, two screenshots, no client left behind. A list form, an
object form and an extension form each photographed, 0.5 to 1.5 MB per image.

2337 tests, eight gates, four review passes.
