### PR TITLE
Say that a bundle did not download, instead of that its types are gone

### DIFF
--- a/.github/workflows/issue-telegram.yml
+++ b/.github/workflows/issue-telegram.yml
@@ -1,0 +1,55 @@
+name: Issue to Telegram
+
+# Sends a message when an issue is opened or reopened. Without both secrets the job does nothing
+# and stays green, so a fork or a clone that has neither is not failed by every issue.
+#
+# workflow_dispatch sends a test line instead, so the token and the chat id can be checked from
+# the Actions tab without waiting for someone to file an issue.
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'Desko77/ai-edt' }}
+
+    steps:
+      - name: Send
+        env:
+          TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          CHAT: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TITLE: ${{ github.event.issue.title }}
+          NUMBER: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          URL: ${{ github.event.issue.html_url }}
+          ACTION: ${{ github.event.action }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ -z "$TOKEN" ] || [ -z "$CHAT" ]; then
+            echo "TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID is not set - nothing sent."
+            exit 0
+          fi
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            HEAD_LINE="AI-EDT: delivery test"
+            TITLE="Run started by ${GITHUB_ACTOR}"
+            URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          else
+            HEAD_LINE="AI-EDT: issue #${NUMBER} ${ACTION} by ${AUTHOR}"
+          fi
+          # The title reaches Telegram through the environment and --data-urlencode, so one
+          # carrying quotes, newlines or markup is sent as text rather than read as request.
+          TEXT=$(printf '%s\n%s\n%s' "$HEAD_LINE" "$TITLE" "$URL")
+          curl --silent --show-error --fail \
+            "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${CHAT}" \
+            --data-urlencode "disable_web_page_preview=true" \
+            --data-urlencode "text=${TEXT}" \
+            --output /dev/null
+          echo "Sent."

--- a/scripts/check-edt-api.py
+++ b/scripts/check-edt-api.py
@@ -36,6 +36,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 import urllib.request
 import zipfile
 
@@ -104,16 +105,28 @@ def target_release():
     return found.group(1) if found else None
 
 
-def fetch(url, cache_path):
-    """Downloads once and reuses. Bundles are large and a census is run repeatedly."""
+def fetch(url, cache_path, attempts=3):
+    """Downloads once and reuses. Bundles are large and a census is run repeatedly.
+
+    Retried, because the answer this asks for is whether a type exists, and a refused download
+    answers a different question. The last failure is raised so the caller can say which.
+    """
     if os.path.exists(cache_path) and os.path.getsize(cache_path) > 0:
         return cache_path
     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-    with urllib.request.urlopen(url, timeout=120) as response:
-        data = response.read()
-    with open(cache_path, "wb") as handle:
-        handle.write(data)
-    return cache_path
+    last = None
+    for attempt in range(attempts):
+        try:
+            with urllib.request.urlopen(url, timeout=120) as response:
+                data = response.read()
+            with open(cache_path, "wb") as handle:
+                handle.write(data)
+            return cache_path
+        except Exception as refused:
+            last = refused
+            if attempt + 1 < attempts:
+                time.sleep(2 * (attempt + 1))
+    raise last
 
 
 def package_index(release, cache_dir):
@@ -177,13 +190,15 @@ def candidate_bundles(fqn, index, bundles):
     return seen
 
 
-def bundle_jar(release, bundle, cache_dir):
+def bundle_jar(release, bundle, cache_dir, refusals=None):
     name, version = bundle
     filename = "%s_%s.jar" % (name, version)
     try:
         return fetch(SITE % release + "plugins/" + filename,
                      os.path.join(cache_dir, release, "plugins", filename))
-    except Exception:
+    except Exception as refused:
+        if refusals is not None:
+            refusals[bundle] = "%s: %s" % (type(refused).__name__, refused)
         return None
 
 
@@ -198,10 +213,12 @@ class Release:
         self.located = {}
         self.declared = {}
         self.missing_bundles = set()
+        self.unreachable = set()
+        self.refusals = {}
 
     def download(self, bundle):
         if bundle not in self.jars:
-            self.jars[bundle] = bundle_jar(self.name, bundle, self.cache_dir)
+            self.jars[bundle] = bundle_jar(self.name, bundle, self.cache_dir, self.refusals)
             if self.jars[bundle] is None:
                 self.missing_bundles.add(bundle)
         return self.jars[bundle]
@@ -217,14 +234,18 @@ class Release:
             return self.located[fqn]
         self.located[fqn] = None
         entry = fqn.replace(".", "/") + ".class"
+        blocked = False
         for bundle in candidate_bundles(fqn, self.index, self.bundles):
             jar = self.download(bundle)
             if jar is None:
+                blocked = True
                 continue
             with zipfile.ZipFile(jar) as archive:
                 if entry in archive.namelist():
                     self.located[fqn] = jar
                     break
+        if self.located[fqn] is None and blocked:
+            self.unreachable.add(fqn)
         return self.located[fqn]
 
     def has_type(self, fqn):
@@ -520,9 +541,11 @@ def check_release(release, types, members, entries, cache_dir):
 
     for fqn in sorted(types):
         if not target.has_type(fqn):
+            if fqn in target.unreachable:
+                continue
             findings.append(("calls", fqn, "", "type not found"))
     unjudged = 0
-    absent_types = {f[1] for f in findings}
+    absent_types = {f[1] for f in findings} | target.unreachable
     for fqn, member in sorted(members):
         if fqn in absent_types:
             continue
@@ -538,6 +561,8 @@ def check_release(release, types, members, entries, cache_dir):
             # Not a class; nothing in a jar answers for it. Counted, never judged.
             continue
         if not target.has_type(fqn):
+            if fqn in target.unreachable:
+                continue
             if kind == "probe":
                 absent_probes.append(fqn)
             else:
@@ -625,7 +650,15 @@ def main():
         target, findings, unjudged, absent_probes = check_release(
             release, types, members, entries, args.cache)
         if target.missing_bundles:
-            log("  %s: %d bundles could not be downloaded" % (release, len(target.missing_bundles)))
+            failed = True
+            log("  %s: %d bundle(s) could not be downloaded - %d type(s) could NOT be checked "
+                "against this release" % (release, len(target.missing_bundles),
+                                          len(target.unreachable)))
+            for bundle in sorted(target.missing_bundles):
+                log("    unreachable: %s_%s.jar - %s"
+                    % (bundle[0], bundle[1], target.refusals.get(bundle, "no reason recorded")))
+            for fqn in sorted(target.unreachable):
+                log("    unchecked: %s" % fqn)
         if findings:
             failed = True
             log("  %s: %d references do not resolve" % (release, len(findings)))

--- a/scripts/check-edt-api.py
+++ b/scripts/check-edt-api.py
@@ -105,13 +105,13 @@ def target_release():
     return found.group(1) if found else None
 
 
-def fetch(url, cache_path, attempts=3):
+def fetch(url, cache_path, attempts=3, refresh=False):
     """Downloads once and reuses. Bundles are large and a census is run repeatedly.
 
     Retried, because the answer this asks for is whether a type exists, and a refused download
     answers a different question. The last failure is raised so the caller can say which.
     """
-    if os.path.exists(cache_path) and os.path.getsize(cache_path) > 0:
+    if not refresh and os.path.exists(cache_path) and os.path.getsize(cache_path) > 0:
         return cache_path
     os.makedirs(os.path.dirname(cache_path), exist_ok=True)
     last = None
@@ -135,8 +135,12 @@ def package_index(release, cache_dir):
     Read from the p2 content metadata rather than by guessing bundle names from package names: the
     two diverge often enough that guessing would report a package missing when it has merely moved.
     """
+    # Read fresh every run, never from the cache. A republished release keeps its version and
+    # changes the qualifier, so a cached index asks for jar names the site no longer carries and
+    # every type in them reads as removed. Measured 07.09: an index from July against jars from
+    # September, five bundles answering 404. The index is a fraction of one bundle.
     content = fetch(SITE % release + "content.jar",
-                    os.path.join(cache_dir, release, "content.jar"))
+                    os.path.join(cache_dir, release, "content.jar"), refresh=True)
     with zipfile.ZipFile(content) as archive:
         xml = archive.read("content.xml").decode("utf-8", "replace")
 


### PR DESCRIPTION
The scheduled census failed twice on 2026-09-07 with 40 references reported as not resolving in 2026.1. Five bundles had not downloaded, and every type they carry was reported as absent from the release. The same census, run locally against a cold cache, reads all five and answers `2026.1: everything we use is there`.

- A type whose bundle did not arrive is counted as unchecked, not reported as absent.
- The report names the unreachable jars, the unchecked types, and the refusal each download ended with. `bundle_jar` swallowed the reason whole, so the log carried no way to tell a refusal from a removal.
- Downloads are retried three times with a growing pause. A refused download leaves no empty file in the cache.
- The run still fails while a bundle is unreachable, under that name rather than as a compatibility finding.

Verified on stubbed downloads: an unreachable bundle yields no findings and its types are listed unchecked; a type genuinely absent from a bundle that did download is still a finding. A stubbed 403 shows three attempts, the recorded reason and no cache file. `scripts/check-edt-api.py --against 2026.1 --check` exits 0 locally.

Also adds `issue-telegram.yml`: new and reopened issues go to Telegram. Without `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` it sends nothing and stays green; `workflow_dispatch` sends a test line.