### PR TITLE
One handshake carries the infobase lock, an address the model lacks is named, a javadoc that documents nothing fails the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,14 @@ jobs:
       - name: Swallowed reflection census
         run: python3 scripts/check-swallowed-reflection.py
 
+      # A javadoc block with no declaration under it documents whatever follows, or nothing. They
+      # arrive when a method moves or is replaced and its old block stays behind, and nothing in the
+      # build says a word, because a comment always compiles. The count may fall and never rise.
+      - name: Orphan javadoc census
+        run: |
+          python3 scripts/tests/test_check_orphan_javadoc.py
+          python3 scripts/check-orphan-javadoc.py --check
+
       # The README tells users to install the skill, so a skill that has fallen behind the code
       # teaches an agent that a capability is absent. That has happened twice: a removed facade left
       # described, and an import stated as refused months after it was built.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -11,7 +11,7 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | ui-bound | 48 | needs a display or an extension point |
 | workspace-bound | 56 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **389** | across 256 test classes |
+| **total** | **389** | across 259 test classes |
 
 ## untested (0)
 
@@ -522,7 +522,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2420 test methods across 256 test classes; 116 classes have a test of their own, median 9 methods each.
+2440 test methods across 259 test classes; 116 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 389 classes have one: 88 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/McpHttpEndpoint.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/McpHttpEndpoint.java
@@ -6,9 +6,9 @@
 
 package ru.aiedt.mcp.server;
 
-import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -271,7 +271,18 @@ public class McpHttpEndpoint
 
     private static final int HTTP_METHOD_NOT_ALLOWED = 405;
 
+    private static final int HTTP_PAYLOAD_TOO_LARGE = 413;
+
     private static final int HTTP_INTERNAL_ERROR = 500;
+
+    /**
+     * The most a request body may carry. Generous on purpose: a module written through
+     * {@code write_module_source} is the largest thing a caller legitimately sends, and a
+     * configuration's largest modules are measured in megabytes, not tens of them.
+     */
+    private static final long MAX_BODY_BYTES = 32L * 1024L * 1024L;
+
+    private static final int BODY_CHUNK_BYTES = 8192;
 
     private static final int HTTP_UNAVAILABLE = 503;
 
@@ -1412,6 +1423,15 @@ public class McpHttpEndpoint
             {
                 body = readBody(exchange);
             }
+            catch (BodyTooLarge tooLarge)
+            {
+                // A body past the limit is the client's to fix, so it is told - unlike a broken
+                // connection, where there is nobody left to tell.
+                Activator.logWarning("MCP request refused: " + tooLarge.getMessage()); //$NON-NLS-1$
+                sendBody(exchange, HTTP_PAYLOAD_TOO_LARGE, "Payload too large: the request body goes past " //$NON-NLS-1$
+                    + tooLarge.limit() + " bytes."); //$NON-NLS-1$
+                return;
+            }
             catch (IOException e)
             {
                 // The request never arrived in full; the client is presumed gone, so nothing is sent
@@ -2137,18 +2157,61 @@ public class McpHttpEndpoint
      */
     private static String readBody(HttpExchange exchange) throws IOException
     {
-        StringBuilder body = new StringBuilder();
-        try (BufferedReader reader =
-            new BufferedReader(new InputStreamReader(exchange.getRequestBody(), StandardCharsets.UTF_8)))
+        return readBody(exchange.getRequestBody(), MAX_BODY_BYTES);
+    }
+
+    /**
+     * Reads a request body, refusing one that goes past a limit.
+     * <p>
+     * The limit is on the bytes actually read, not on {@code Content-Length}. A request may arrive
+     * without that header, may arrive chunked, and may declare a smaller number than it sends - so
+     * the header decides nothing, and a reader that trusts it can still be handed a body of any
+     * size. Counting while reading is what a limit has to mean.
+     * </p>
+     *
+     * @param stream the request body
+     * @param limit the most bytes that may be read
+     * @return the body as text
+     * @throws BodyTooLarge when the body goes past the limit
+     * @throws IOException when the connection breaks
+     */
+    static String readBody(InputStream stream, long limit) throws IOException
+    {
+        ByteArrayOutputStream collected = new ByteArrayOutputStream();
+        byte[] buffer = new byte[BODY_CHUNK_BYTES];
+        long total = 0;
+        int read = stream.read(buffer);
+        while (read >= 0)
         {
-            String line = reader.readLine();
-            while (line != null)
+            total += read;
+            if (total > limit)
             {
-                body.append(line);
-                line = reader.readLine();
+                throw new BodyTooLarge(limit);
             }
+            collected.write(buffer, 0, read);
+            read = stream.read(buffer);
         }
-        return body.toString();
+        return new String(collected.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    /** A request body past the limit. Carries the limit so the refusal can name it. */
+    static final class BodyTooLarge
+        extends IOException
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final long limit;
+
+        BodyTooLarge(long limit)
+        {
+            super("the request body goes past " + limit + " bytes"); //$NON-NLS-1$ //$NON-NLS-2$
+            this.limit = limit;
+        }
+
+        long limit()
+        {
+            return limit;
+        }
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
@@ -957,6 +957,41 @@ public final class BmExtensionHelper
      * {@link MetadataTypeCatalog}, and walking child collections by reflection
      * ({@code getForms()}, {@code getAttributes()}, ...).
      */
+    /**
+     * Whether the model of a project holds the object a FQN names.
+     * <p>
+     * The one answer in this codebase to "does this address exist", and it is not
+     * {@code getTopObjectByFqn} alone: a form, a template, an attribute or a command is NOT a BM
+     * top object, and the index answers <code>null</code> for every one of them. Measured on a
+     * stand: a data processor's existing form and existing template both came back unresolved from
+     * the index while their files sat on disk. A caller that reports "not found" from the index
+     * alone therefore denies objects that are there.
+     * </p>
+     *
+     * @param project the project whose model is asked
+     * @param fqn the address, top-level or child
+     * @return <code>true</code> when the model holds it
+     */
+    public static boolean addressResolves(IProject project, String fqn)
+    {
+        if (project == null || fqn == null || fqn.trim().isEmpty())
+        {
+            return false;
+        }
+        try
+        {
+            return resolveSourceEObject(project, fqn.trim()) != null;
+        }
+        catch (Exception | LinkageError failed)
+        {
+            // An address that cannot be looked up is not an address that is absent: saying "not
+            // found" on a lookup failure is the false claim this method exists to prevent.
+            Activator.logWarning("could not resolve the address " + fqn + ": " //$NON-NLS-1$ //$NON-NLS-2$
+                + failed);
+            return true;
+        }
+    }
+
     private static EObject resolveSourceEObject(IProject baseProject, String fqn)
     {
         if (fqn == null || fqn.isEmpty())

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmInfobaseExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmInfobaseExtensionHelper.java
@@ -135,29 +135,21 @@ public final class BmInfobaseExtensionHelper
                 r.failureKind = ErrorTags.BUSY.wire();
                 return r;
             }
-            if (ctx.lock != null) ctx.lock.lock();
             try
             {
                 // Same disconnect/reconnect as install/uninstall: the list
                 // thick-client also needs EDT's designer agent off the file
                 // infobase, or it blocks on the monopoly (row 55).
-                boolean disconnected = disconnectForThickClient(ctx);
-                try
-                {
+                underThickClientHandshake(ctx, () -> {
                     List<String> exts = ctx.launcher.listConfigurationExtensions(ctx.component,
                         ctx.infobase, ctx.args);
                     r.ok = true;
                     r.extensions = exts != null ? exts : Collections.emptyList();
-                }
-                finally
-                {
-                    if (disconnected) reconnectInfobase(ctx);
-                }
+                });
             }
             finally
             {
                 claim.close();
-                if (ctx.lock != null) ctx.lock.unlock();
             }
         }
         catch (Throwable e)
@@ -200,24 +192,16 @@ public final class BmInfobaseExtensionHelper
                 r.failureKind = ErrorTags.BUSY.wire();
                 return r;
             }
-            if (ctx.lock != null) ctx.lock.lock();
             try
             {
-                boolean disconnected = disconnectForThickClient(ctx);
-                try
-                {
+                underThickClientHandshake(ctx, () -> {
                     ctx.launcher.deleteConfigurationExtension(ctx.component, ctx.infobase, ctx.args, name);
                     r.ok = true;
-                }
-                finally
-                {
-                    if (disconnected) reconnectInfobase(ctx);
-                }
+                });
             }
             finally
             {
                 claim.close();
-                if (ctx.lock != null) ctx.lock.unlock();
             }
         }
         catch (Throwable e)
@@ -372,6 +356,67 @@ public final class BmInfobaseExtensionHelper
             if (ctx.lock != null)
             {
                 ctx.lock.unlock();
+            }
+        }
+    }
+
+    /**
+     * Runs a thick-client call the way EDT's own interface does: the infobase is released, the
+     * call runs under the per-infobase lock, and the infobase is taken back.
+     * <p>
+     * The ORDER is the whole point, and it is why this is one method rather than an idiom repeated
+     * at each call site. EDT takes that same lock inside {@code connectInfobase}, AFTER the
+     * connection's monitor. A caller that holds the lock across the reconnection therefore asks for
+     * the two in the opposite order to EDT's own background synchronization worker, and the two
+     * deadlock - measured with a thread dump, with the worker holding the monitor and waiting for
+     * the lock while the call held the lock and waited for the monitor.
+     * </p>
+     *
+     * @param ctx the resolved launcher context
+     * @param work the launcher call
+     * @throws Exception whatever the call throws
+     */
+    static void underThickClientHandshake(LauncherContext ctx, Work work) throws Exception
+    {
+        handshakeOrder(ctx.lock, () -> disconnectForThickClient(ctx), work, () -> reconnectInfobase(ctx));
+    }
+
+    /**
+     * The order itself, with every step handed in, so that a test can watch it without EDT.
+     *
+     * @param lock the per-infobase lock; <code>null</code> when this runtime has none
+     * @param release releases the infobase and says whether it had been connected
+     * @param work the launcher call, run under the lock and nothing else
+     * @param reconnect takes the infobase back, run only when the release reported a connection
+     * @throws Exception whatever the work throws, after the infobase has been taken back
+     */
+    static void handshakeOrder(java.util.concurrent.locks.Lock lock,
+        java.util.function.BooleanSupplier release, Work work, Runnable reconnect) throws Exception
+    {
+        boolean disconnected = release.getAsBoolean();
+        try
+        {
+            if (lock != null)
+            {
+                lock.lock();
+            }
+            try
+            {
+                work.run();
+            }
+            finally
+            {
+                if (lock != null)
+                {
+                    lock.unlock();
+                }
+            }
+        }
+        finally
+        {
+            if (disconnected)
+            {
+                reconnect.run();
             }
         }
     }
@@ -746,7 +791,6 @@ public final class BmInfobaseExtensionHelper
                 r.failureKind = ErrorTags.BUSY.wire();
                 return r;
             }
-            if (ctx.lock != null) ctx.lock.lock();
             try
             {
                 // Mirror installExtension: temporarily disconnect EDT's persistent
@@ -755,21 +799,14 @@ public final class BmInfobaseExtensionHelper
                 // EDT's agent the export thick-client blocks on the monopoly and the
                 // call hangs until the MCP timeout (row 55). ctx.lock alone does not
                 // release that platform lock (live-verified).
-                boolean disconnected = disconnectForThickClient(ctx);
-                try
-                {
+                underThickClientHandshake(ctx, () -> {
                     ctx.launcher.exportCfFromInfobase(ctx.component, ctx.infobase, ctx.args,
                         extensionName, dest);
-                }
-                finally
-                {
-                    if (disconnected) reconnectInfobase(ctx);
-                }
+                });
             }
             finally
             {
                 claim.close();
-                if (ctx.lock != null) ctx.lock.unlock();
             }
         }
         catch (Throwable e)
@@ -867,26 +904,18 @@ public final class BmInfobaseExtensionHelper
                 r.failureKind = ErrorTags.BUSY.wire();
                 return r;
             }
-            if (ctx.lock != null) ctx.lock.lock();
             try
             {
                 // Same disconnect/reconnect as exportExtension: the dump thick-client needs
                 // EDT's designer agent off the file infobase or it blocks on the monopoly.
-                boolean disconnected = disconnectForThickClient(ctx);
-                try
-                {
+                underThickClientHandshake(ctx, () -> {
                     // null extension name = the MAIN configuration (not an extension).
                     ctx.launcher.exportCfFromInfobase(ctx.component, ctx.infobase, ctx.args, null, dest);
-                }
-                finally
-                {
-                    if (disconnected) reconnectInfobase(ctx);
-                }
+                });
             }
             finally
             {
                 claim.close();
-                if (ctx.lock != null) ctx.lock.unlock();
             }
         }
         catch (Throwable e)
@@ -1085,12 +1114,9 @@ public final class BmInfobaseExtensionHelper
                 r.failureKind = ErrorTags.BUSY.wire();
                 return r;
             }
-            if (ctx.lock != null) ctx.lock.lock();
             try
             {
-                boolean disconnected = disconnectForThickClient(ctx);
-                try
-                {
+                underThickClientHandshake(ctx, () -> {
                     Object out = execM.invoke(ctx.launcher, command,
                         ctx.component.getInstallation(), ctx.infobase, ctx.args);
                     // Defense in depth: strip the infobase password out of the designer log
@@ -1098,16 +1124,11 @@ public final class BmInfobaseExtensionHelper
                     // channel that carries the /P argv token.
                     r.designerLog = trimLog(redactSecret(out == null ? null : (String)out,
                         ctx.args.getPassword()));
-                }
-                finally
-                {
-                    if (disconnected) reconnectInfobase(ctx);
-                }
+                });
             }
             finally
             {
                 claim.close();
-                if (ctx.lock != null) ctx.lock.unlock();
             }
         }
         catch (java.lang.reflect.InvocationTargetException e)

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ProjectProblemsReader.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ProjectProblemsReader.java
@@ -39,6 +39,7 @@ import ru.aiedt.mcp.server.wire.ToolResult;
 import ru.aiedt.mcp.server.session.SessionChangeTracker;
 import ru.aiedt.mcp.server.toolkit.IMcpTool;
 import ru.aiedt.mcp.server.support.MarkdownTableHelper;
+import ru.aiedt.mcp.server.support.BmExtensionHelper;
 import ru.aiedt.mcp.server.support.MetadataTypeCatalog;
 import ru.aiedt.mcp.server.support.ProjectResolver;
 import ru.aiedt.mcp.server.support.ProjectStateGuard;
@@ -329,6 +330,10 @@ public class ProjectProblemsReader
             {
                 objectFqns.addAll(MetadataTypeCatalog.getAllFqnVariants(fqn));
             }
+            // Named before the markers are counted. An address the model does not hold matches no
+            // marker, so the answer below is a clean page - and a clean page over a mistyped FQN
+            // reads as "this object has no errors", which is the opposite of what happened.
+            String unresolved = unresolvedNotice(projectName, objects);
 
             Filter filter =
                 new Filter(projectName, severityFilter, checkId, objectFqns, sessionFqns, sessionScope, fileFilter);
@@ -364,8 +369,8 @@ public class ProjectProblemsReader
 
             if (compact)
             {
-                return formatCompact(collected, resolvedScope, projectName, severity, checkId, objects,
-                    collectLimit);
+                return unresolved + formatCompact(collected, resolvedScope, projectName, severity, checkId,
+                    objects, collectLimit);
             }
             if ("project".equals(resolvedScope) && collected.size() >= limit) //$NON-NLS-1$
             {
@@ -387,12 +392,13 @@ public class ProjectProblemsReader
                     // sat collected and were thrown away. Finding out which checks fire on a
                     // large configuration then took one call per object. The warning belongs
                     // in front of the rows, not instead of them.
-                    return capNotice(total, collected.size(), filter.isNarrowed())
+                    return unresolved + capNotice(total, collected.size(), filter.isNarrowed())
                         + formatMarkers(collected, resolvedScope, projectName, severity, checkId,
                             objects, limit, extraInfo);
                 }
             }
-            return formatMarkers(collected, resolvedScope, projectName, severity, checkId, objects, limit, extraInfo);
+            return unresolved
+                + formatMarkers(collected, resolvedScope, projectName, severity, checkId, objects, limit, extraInfo);
         }
         catch (Exception e)
         {
@@ -495,6 +501,80 @@ public class ProjectProblemsReader
      * @param objects the object filter; never <code>null</code>.
      * @return the markdown.
      */
+    /**
+     * The heading that names the requested addresses the model does not hold.
+     * <p>
+     * Asked through {@link BmExtensionHelper#addressResolves}, which is the same question
+     * {@code revalidate_objects} answers, and which knows that a form, a template or an attribute
+     * is not a BM top object. Without a named project there is nothing to ask, and the notice is
+     * empty.
+     * </p>
+     *
+     * @param projectName the project the addresses belong to; may be <code>null</code>
+     * @param objects the requested addresses; may be empty
+     * @return the notice, ending in a blank line, or an empty string when every address resolves
+     */
+    static String unresolvedNotice(String projectName, List<String> objects)
+    {
+        if (projectName == null || projectName.isEmpty() || objects == null || objects.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectName);
+        if (!project.exists())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return describeMissing(missingAmong(objects, fqn -> BmExtensionHelper.addressResolves(project, fqn)));
+    }
+
+    /**
+     * The addresses a resolver does not recognise, in the order they were asked for.
+     * <p>
+     * Split out from the lookup so the decision can be driven by a test: a mixed request, where one
+     * address stands and another does not, is the case that matters and the one a workspace-bound
+     * method cannot be asked about.
+     * </p>
+     *
+     * @param objects the requested addresses
+     * @param resolves answers whether the model holds an address
+     * @return the addresses it does not hold; empty when every one of them stands
+     */
+    static List<String> missingAmong(List<String> objects, java.util.function.Predicate<String> resolves)
+    {
+        List<String> missing = new ArrayList<>();
+        if (objects == null)
+        {
+            return missing;
+        }
+        for (String fqn : objects)
+        {
+            if (!resolves.test(fqn))
+            {
+                missing.add(fqn);
+            }
+        }
+        return missing;
+    }
+
+    /**
+     * The wording of the notice, kept apart from the lookup so it can be read without a workspace.
+     *
+     * @param missing the addresses the model does not hold; empty gives an empty notice
+     * @return the notice, ending in a blank line
+     */
+    static String describeMissing(List<String> missing)
+    {
+        if (missing == null || missing.isEmpty())
+        {
+            return ""; //$NON-NLS-1$
+        }
+        return "# Addresses Not In The Model\n\n" //$NON-NLS-1$
+            + "The project holds no object under: " + String.join(", ", missing) //$NON-NLS-1$ //$NON-NLS-2$
+            + ".\nNothing below is filtered to " + (missing.size() == 1 ? "that address" : "them") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            + " - check the spelling of the FQN.\n\n"; //$NON-NLS-1$
+    }
+
     // Package-visible for ProjectProblemsSeverityNoticeTest: the compact path once
     // reached this with the filters stripped, and told a caller who had asked for ALL
     // that the default was in force. A test is what keeps the two paths saying the same

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/ARequestBodyHasALimitTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/ARequestBodyHasALimitTest.java
@@ -1,0 +1,110 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+/**
+ * The body is capped by the bytes read, not by what the request claims to be sending.
+ * <p>
+ * {@code Content-Length} decides nothing here on purpose: a request may arrive without the header,
+ * may arrive chunked, and may declare a smaller number than it sends. A reader that trusts the
+ * header can still be handed a body of any size, which is the same as having no limit.
+ * </p>
+ */
+public class ARequestBodyHasALimitTest
+{
+    private static InputStream streamOf(String text)
+    {
+        return new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void aBodyUnderTheLimitIsRead() throws IOException
+    {
+        assertEquals("{\"jsonrpc\":\"2.0\"}", //$NON-NLS-1$
+            McpHttpEndpoint.readBody(streamOf("{\"jsonrpc\":\"2.0\"}"), 1024)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aBodyExactlyAtTheLimitIsRead() throws IOException
+    {
+        String body = "0123456789"; //$NON-NLS-1$
+        assertEquals(body, McpHttpEndpoint.readBody(streamOf(body), 10));
+    }
+
+    @Test
+    public void aBodyOneByteOverTheLimitIsRefused()
+    {
+        try
+        {
+            McpHttpEndpoint.readBody(streamOf("01234567890"), 10); //$NON-NLS-1$
+            fail("a body past the limit has to be refused"); //$NON-NLS-1$
+        }
+        catch (IOException refused)
+        {
+            assertTrue(refused instanceof McpHttpEndpoint.BodyTooLarge);
+            assertEquals(10L, ((McpHttpEndpoint.BodyTooLarge)refused).limit());
+        }
+    }
+
+    @Test
+    public void aStreamThatNeverEndsIsStoppedAtTheLimit()
+    {
+        // What a declared length cannot protect against: the stream simply keeps going. This one
+        // would never end on its own, so the test finishing at all IS the assertion.
+        InputStream endless = new InputStream()
+        {
+            @Override
+            public int read()
+            {
+                return 'x';
+            }
+
+            @Override
+            public int read(byte[] into, int off, int len)
+            {
+                java.util.Arrays.fill(into, off, off + len, (byte)'x');
+                return len;
+            }
+        };
+
+        try
+        {
+            McpHttpEndpoint.readBody(endless, 64L * 1024L);
+            fail("an endless body has to be refused"); //$NON-NLS-1$
+        }
+        catch (IOException refused)
+        {
+            assertTrue(refused instanceof McpHttpEndpoint.BodyTooLarge);
+        }
+    }
+
+    @Test
+    public void anEmptyBodyIsEmptyRatherThanARefusal() throws IOException
+    {
+        assertEquals("", McpHttpEndpoint.readBody(streamOf(""), 10)); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void theBodyKeepsItsNewlinesAndNonAsciiText() throws IOException
+    {
+        // The previous reader joined lines and dropped every newline, so a body was not what was
+        // sent. A JSON document survived that; a module source inside one does not.
+        String body = "{\"code\":\"Процедура Тест()\nКонецПроцедуры\"}"; //$NON-NLS-1$
+        assertEquals(body, McpHttpEndpoint.readBody(streamOf(body), 4096));
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/TheHandshakeHoldsTheLockAroundTheCallAloneTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/TheHandshakeHoldsTheLockAroundTheCallAloneTest.java
@@ -1,0 +1,192 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.Test;
+
+/**
+ * The per-infobase lock is taken after the release and given back before the reconnection.
+ * <p>
+ * Measured with a thread dump: EDT takes that same lock inside {@code connectInfobase}, after the
+ * connection's monitor, while its background synchronization worker holds the monitor and waits for
+ * the lock. A call that holds the lock across its own reconnection asks for the two in the opposite
+ * order, and the two deadlock. The order below is therefore the fix, and this is what guards it -
+ * a live check on one or two of the five paths would not.
+ * </p>
+ */
+public class TheHandshakeHoldsTheLockAroundTheCallAloneTest
+{
+    /** A lock that writes down when it is taken and given back. */
+    private static final class RecordingLock
+        extends ReentrantLock
+    {
+        private static final long serialVersionUID = 1L;
+
+        private final List<String> order;
+
+        RecordingLock(List<String> order)
+        {
+            this.order = order;
+        }
+
+        @Override
+        public void lock()
+        {
+            order.add("lock"); //$NON-NLS-1$
+            super.lock();
+        }
+
+        @Override
+        public void unlock()
+        {
+            order.add("unlock"); //$NON-NLS-1$
+            super.unlock();
+        }
+    }
+
+    @Test
+    public void theCallRunsUnderTheLockAndTheInfobaseIsReleasedAroundIt() throws Exception
+    {
+        List<String> order = new ArrayList<>();
+        Lock lock = new RecordingLock(order);
+
+        BmInfobaseExtensionHelper.handshakeOrder(lock, () -> {
+            order.add("release"); //$NON-NLS-1$
+            return true;
+        }, () -> order.add("launcher"), () -> order.add("reconnect")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(Arrays.asList("release", "lock", "launcher", "unlock", "reconnect"), order); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+
+    @Test
+    public void theLockIsGivenBackAndTheInfobaseTakenBackWhenTheCallThrows()
+    {
+        List<String> order = new ArrayList<>();
+        Lock lock = new RecordingLock(order);
+
+        try
+        {
+            BmInfobaseExtensionHelper.handshakeOrder(lock, () -> {
+                order.add("release"); //$NON-NLS-1$
+                return true;
+            }, () -> {
+                order.add("launcher"); //$NON-NLS-1$
+                throw new IllegalStateException("the Designer failed"); //$NON-NLS-1$
+            }, () -> order.add("reconnect")); //$NON-NLS-1$
+            fail("the failure of the call has to reach the caller"); //$NON-NLS-1$
+        }
+        catch (Exception expected)
+        {
+            assertEquals("the Designer failed", expected.getMessage()); //$NON-NLS-1$
+        }
+
+        assertEquals(Arrays.asList("release", "lock", "launcher", "unlock", "reconnect"), order); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        assertFalse("the lock is not left held", ((ReentrantLock)lock).isLocked()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void anInfobaseThatWasNotConnectedIsNotReconnected() throws Exception
+    {
+        List<String> order = new ArrayList<>();
+        Lock lock = new RecordingLock(order);
+
+        BmInfobaseExtensionHelper.handshakeOrder(lock, () -> {
+            order.add("release"); //$NON-NLS-1$
+            return false;
+        }, () -> order.add("launcher"), () -> order.add("reconnect")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(Arrays.asList("release", "lock", "launcher", "unlock"), order); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+    }
+
+    @Test
+    public void aReleaseThatThrowsRunsNeitherTheCallNorTheReconnection()
+    {
+        List<String> order = new ArrayList<>();
+        Lock lock = new RecordingLock(order);
+
+        try
+        {
+            BmInfobaseExtensionHelper.handshakeOrder(lock, () -> {
+                order.add("release"); //$NON-NLS-1$
+                throw new IllegalStateException("the infobase could not be released"); //$NON-NLS-1$
+            }, () -> order.add("launcher"), () -> order.add("reconnect")); //$NON-NLS-1$ //$NON-NLS-2$
+            fail("a release that failed has to reach the caller"); //$NON-NLS-1$
+        }
+        catch (Exception expected)
+        {
+            assertTrue(expected.getMessage(), expected.getMessage().contains("could not be released")); //$NON-NLS-1$
+        }
+
+        // The Designer must not run against an infobase EDT still holds, and there is nothing to
+        // take back.
+        assertEquals(Arrays.asList("release"), order); //$NON-NLS-1$
+        assertFalse("the lock was never taken", ((ReentrantLock)lock).isLocked()); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aRuntimeWithoutTheLockStillReleasesAndTakesTheInfobaseBack() throws Exception
+    {
+        List<String> order = new ArrayList<>();
+
+        BmInfobaseExtensionHelper.handshakeOrder(null, () -> {
+            order.add("release"); //$NON-NLS-1$
+            return true;
+        }, () -> order.add("launcher"), () -> order.add("reconnect")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(Arrays.asList("release", "launcher", "reconnect"), order); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void theInfobaseIsTakenBackEvenWhenGivingTheLockBackFails()
+    {
+        List<String> order = new ArrayList<>();
+        Lock lock = new ReentrantLock()
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void lock()
+            {
+                order.add("lock"); //$NON-NLS-1$
+            }
+
+            @Override
+            public void unlock()
+            {
+                order.add("unlock"); //$NON-NLS-1$
+                throw new IllegalMonitorStateException("not this thread's lock"); //$NON-NLS-1$
+            }
+        };
+
+        try
+        {
+            BmInfobaseExtensionHelper.handshakeOrder(lock, () -> {
+                order.add("release"); //$NON-NLS-1$
+                return true;
+            }, () -> order.add("launcher"), () -> order.add("reconnect")); //$NON-NLS-1$ //$NON-NLS-2$
+            fail("the failure has to reach the caller"); //$NON-NLS-1$
+        }
+        catch (Exception expected)
+        {
+            // The infobase still has to come back: leaving it disconnected is the one outcome the
+            // user sees and cannot undo from here.
+        }
+
+        assertEquals(Arrays.asList("release", "lock", "launcher", "unlock", "reconnect"), order); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AnAddressTheModelLacksIsNamedTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AnAddressTheModelLacksIsNamedTest.java
@@ -1,0 +1,111 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+/**
+ * A requested address the model does not hold is named, instead of answering a clean page.
+ * <p>
+ * Measured on a stand: {@code objects=["Document.НетТакого"]} answered "Nothing Found" and said
+ * nothing about the address, so a mistyped FQN read as "this object has no errors". The same
+ * measurement showed why the index alone cannot decide it: a data processor's existing form and
+ * existing template both come back unresolved from {@code getTopObjectByFqn}, because neither is a
+ * BM top object. The notice therefore asks the shared resolver, and stays silent without a project
+ * to ask.
+ * </p>
+ */
+public class AnAddressTheModelLacksIsNamedTest
+{
+    @Test
+    public void withoutAProjectThereIsNothingToAsk()
+    {
+        assertEquals("", ProjectProblemsReader.unresolvedNotice(null, //$NON-NLS-1$
+            Collections.singletonList("Document.Anything"))); //$NON-NLS-1$
+        assertEquals("", ProjectProblemsReader.unresolvedNotice("", //$NON-NLS-1$ //$NON-NLS-2$
+            Collections.singletonList("Document.Anything"))); //$NON-NLS-1$
+    }
+
+    @Test
+    public void withoutAddressesThereIsNothingToName()
+    {
+        assertEquals("", ProjectProblemsReader.unresolvedNotice("AnyProject", null)); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("", ProjectProblemsReader.unresolvedNotice("AnyProject", //$NON-NLS-1$ //$NON-NLS-2$
+            Collections.<String> emptyList()));
+    }
+
+    @Test
+    public void aProjectThatIsNotInTheWorkspaceIsNotAnAbsentAddress()
+    {
+        // The caller is already told the project is unknown, by its own refusal. Naming every
+        // address as missing on top of that would blame the addresses for the project.
+        assertEquals("", ProjectProblemsReader.unresolvedNotice( //$NON-NLS-1$
+            "NoSuchProjectInThisWorkspace", Arrays.asList("Document.A", "Catalog.B"))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    @Test
+    public void theNoticeNamesTheAddressAndTellsTheReaderWhatToCheck()
+    {
+        // The text is what a caller reads instead of a clean page; pin its substance, not its
+        // wording beyond the parts that carry meaning.
+        String notice = ProjectProblemsReader.describeMissing(Arrays.asList("Document.НетТакого")); //$NON-NLS-1$
+        assertTrue(notice, notice.contains("Document.НетТакого")); //$NON-NLS-1$
+        assertTrue(notice, notice.contains("spelling")); //$NON-NLS-1$
+        assertFalse("a single address is not addressed in the plural", notice.contains("them")); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void aMixedRequestNamesOnlyTheAddressThatIsMissing()
+    {
+        // The case that matters, and the one a workspace-bound method cannot be asked about: the
+        // answer must not blame an address that stands.
+        java.util.List<String> missing = ProjectProblemsReader.missingAmong(
+            Arrays.asList("Document.Real", "Document.НетТакого"), //$NON-NLS-1$ //$NON-NLS-2$
+            fqn -> "Document.Real".equals(fqn)); //$NON-NLS-1$
+
+        assertEquals(Collections.singletonList("Document.НетТакого"), missing); //$NON-NLS-1$
+    }
+
+    @Test
+    public void anExistingFormOrTemplateIsNotCalledMissing()
+    {
+        // Measured on a stand: getTopObjectByFqn answers null for both, though both exist. The
+        // resolver handed in here is the one that knows child addresses; the point of the test is
+        // that the notice reports whatever IT says, and adds nothing of its own.
+        java.util.List<String> missing = ProjectProblemsReader.missingAmong(
+            Arrays.asList("DataProcessor.X.Form.Форма", "DataProcessor.X.Template.Схема"), //$NON-NLS-1$ //$NON-NLS-2$
+            fqn -> true);
+
+        assertTrue(missing.toString(), missing.isEmpty());
+        assertEquals("", ProjectProblemsReader.describeMissing(missing)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void everyAddressMissingIsEveryAddressNamed()
+    {
+        java.util.List<String> missing = ProjectProblemsReader.missingAmong(
+            Arrays.asList("A.B", "C.D"), fqn -> false); //$NON-NLS-1$ //$NON-NLS-2$
+
+        assertEquals(Arrays.asList("A.B", "C.D"), missing); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    @Test
+    public void severalAddressesAreAllNamed()
+    {
+        String notice = ProjectProblemsReader.describeMissing(Arrays.asList("Document.A", "Catalog.B")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertTrue(notice, notice.contains("Document.A")); //$NON-NLS-1$
+        assertTrue(notice, notice.contains("Catalog.B")); //$NON-NLS-1$
+        assertTrue(notice, notice.contains("them")); //$NON-NLS-1$
+    }
+}

--- a/scripts/check-orphan-javadoc.py
+++ b/scripts/check-orphan-javadoc.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""A javadoc block documents the declaration under it, or it documents nothing.
+
+An orphan is a `/** ... */` block with no declaration after it: the next thing in the file is
+another javadoc block, a closing brace, or the end of the file. It reads as documentation of
+whatever follows and documents something else, or nothing at all - and nothing in the build says a
+word, because a comment always compiles.
+
+They arrive the same way every time: a block is inserted above a method that later moves or is
+replaced, and the old block stays behind. One was found by eye in this codebase - a doubled block
+left by an earlier insertion - which is what a census is for.
+
+Reports by default; `--check` fails the build when any orphan stands.
+"""
+
+import pathlib
+import re
+import sys
+
+# The orphans standing when the check was written. It only ever goes down: a fix lowers it,
+# and nothing may raise it.
+BASELINE = 63
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SOURCES = [
+    ROOT / "mcp/bundles/ru.aiedt.mcp.server/src",
+    ROOT / "mcp/tests/ru.aiedt.mcp.server.tests/src",
+]
+
+# What may legitimately stand between a javadoc block and the declaration it documents.
+BETWEEN = re.compile(r"^\s*(@\w[\w.]*(\(.*\))?\s*)+$")
+LINE_COMMENT = re.compile(r"^\s*//")
+
+# A declaration the block can be documenting. Kept deliberately wide: the question is whether
+# SOMETHING is declared, not what kind - a narrow list would report a legitimate block as an
+# orphan, and a check that cries wolf gets switched off.
+DECLARATION = re.compile(
+    r"^\s*("
+    r"(public|protected|private|static|final|abstract|synchronized|native|default|transient|volatile|strictfp)\s"
+    r"|class\s|interface\s|enum\s|record\s|@interface\s"
+    r"|package\s|import\s"
+    r"|[\w.\[\]]+(<[^>]*>)?(\[\])*\s+\w+\s*[;=(]"
+    r"|\w+\s*\("
+    # An enum constant: a name, optional arguments, then a comma, a semicolon or a body.
+    r"|\w+\s*(\(.*\))?\s*[,;{]\s*$"
+    # The last enum constant carries no comma.
+    r"|\w+\s*$"
+    r")"
+)
+
+
+def orphans_in(text):
+    """The 1-based line numbers of javadoc blocks that document nothing."""
+    lines = text.split("\n")
+    found = []
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if not stripped.startswith("/**"):
+            index += 1
+            continue
+        start = index
+        # Walk to the end of the block. A single-line /** ... */ ends on its own line.
+        end = start
+        if "*/" not in stripped[2:]:
+            end += 1
+            while end < len(lines) and "*/" not in lines[end]:
+                end += 1
+        if end >= len(lines):
+            found.append(start + 1)
+            break
+        # The next thing that carries meaning.
+        after = end + 1
+        while after < len(lines):
+            nxt = lines[after].strip()
+            if not nxt or LINE_COMMENT.match(lines[after]) or BETWEEN.match(lines[after]):
+                after += 1
+                continue
+            break
+        if after >= len(lines) or lines[after].strip().startswith("/**") \
+                or lines[after].strip().startswith("}") \
+                or not DECLARATION.match(lines[after]):
+            found.append(start + 1)
+        index = end + 1
+    return found
+
+
+def main():
+    check = "--check" in sys.argv
+    total_files = 0
+    hits = []
+    for source in SOURCES:
+        if not source.exists():
+            continue
+        for path in sorted(source.rglob("*.java")):
+            total_files += 1
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for line in orphans_in(text):
+                hits.append((path.relative_to(ROOT).as_posix(), line))
+
+    for path, line in hits:
+        print("%s:%d: javadoc block documents no declaration" % (path, line))
+    print("%d java files: %d orphan javadoc blocks" % (total_files, len(hits)))
+    if check:
+        if len(hits) > BASELINE:
+            print("FAIL: %d orphan blocks, above the baseline of %d - a new one was added."
+                  % (len(hits), BASELINE))
+            return 1
+        if len(hits) < BASELINE:
+            print("The baseline is stale: %d orphan blocks stand, below the recorded %d. "
+                  "Lower BASELINE in this script to %d so the ground that was won is held."
+                  % (len(hits), BASELINE, len(hits)))
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_orphan_javadoc.py
+++ b/scripts/tests/test_check_orphan_javadoc.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""The detector is checked against a fixture, so it keeps detecting.
+
+A census is only worth the build step it occupies if it still finds what it was written to find,
+and still leaves alone what it was calibrated to leave alone. Both halves are here: every shape
+that was a false positive during calibration is pinned as legitimate, and every shape that was a
+real finding is pinned as an orphan.
+
+Run: python3 scripts/tests/test_check_orphan_javadoc.py
+"""
+
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+import importlib.util
+
+SPEC = importlib.util.spec_from_file_location(
+    "check_orphan_javadoc",
+    pathlib.Path(__file__).resolve().parent.parent / "check-orphan-javadoc.py")
+CHECKER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECKER)
+
+
+class OrphansAreFound(unittest.TestCase):
+    """What the detector must report."""
+
+    def test_javadoc_followed_by_javadoc(self):
+        source = (
+            "/**\n"
+            " * Left behind when its method was replaced.\n"
+            " */\n"
+            "/**\n"
+            " * Documents the method below.\n"
+            " */\n"
+            "public void work()\n"
+            "{\n"
+            "}\n")
+        self.assertEqual([1], CHECKER.orphans_in(source))
+
+    def test_javadoc_before_a_closing_brace(self):
+        source = (
+            "public class A\n"
+            "{\n"
+            "    /**\n"
+            "     * Documents nothing: the class ends here.\n"
+            "     */\n"
+            "}\n")
+        self.assertEqual([3], CHECKER.orphans_in(source))
+
+    def test_javadoc_at_the_end_of_the_file(self):
+        source = "/**\n * Nothing follows.\n */\n"
+        self.assertEqual([1], CHECKER.orphans_in(source))
+
+    def test_an_annotation_does_not_rescue_an_orphan(self):
+        # Measured in this codebase: a block, an annotation, then another block. The first pair
+        # documents nothing.
+        source = (
+            "/** Adds an item to a raw list. */\n"
+            "@SuppressWarnings({ \"rawtypes\", \"unchecked\" })\n"
+            "/**\n"
+            " * Documents the method below.\n"
+            " */\n"
+            "public void add()\n"
+            "{\n"
+            "}\n")
+        self.assertEqual([1], CHECKER.orphans_in(source))
+
+
+class LegitimateBlocksAreLeftAlone(unittest.TestCase):
+    """Every shape that was a false positive while the pattern was being calibrated."""
+
+    def test_the_file_header_above_a_package(self):
+        source = (
+            "/**\n"
+            " * AI-EDT - 1C AI tools for EDT\n"
+            " */\n"
+            "\n"
+            "package ru.aiedt.mcp.server;\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+    def test_an_enum_constant(self):
+        source = (
+            "public enum Kind\n"
+            "{\n"
+            "    /** The first. */\n"
+            "    LEGACY,\n"
+            "\n"
+            "    /** The last, which carries no comma. */\n"
+            "    UNSUPPORTED\n"
+            "}\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+    def test_a_generic_return_type_with_a_space(self):
+        source = (
+            "/**\n"
+            " * Documents the method below.\n"
+            " */\n"
+            "Map<String, Integer> sectionMap()\n"
+            "{\n"
+            "}\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+    def test_an_annotation_between_the_block_and_its_method(self):
+        source = (
+            "/**\n"
+            " * Documents the method below.\n"
+            " */\n"
+            "@Override\n"
+            "public void run()\n"
+            "{\n"
+            "}\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+    def test_a_single_line_block_above_a_field(self):
+        source = (
+            "/** The port this server listens on. */\n"
+            "private static final int PORT = 12250;\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+    def test_a_line_comment_between_the_block_and_its_method(self):
+        source = (
+            "/**\n"
+            " * Documents the method below.\n"
+            " */\n"
+            "// Why it is written this way.\n"
+            "public void run()\n"
+            "{\n"
+            "}\n")
+        self.assertEqual([], CHECKER.orphans_in(source))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed

- **One handshake carries the infobase lock.** `listExtensions`, `uninstallExtension`, `exportExtension`, `exportConfigurationCf` and `installExtension` each held `getLock(infobase)` across `disconnectInfobase` and `connectInfobase`. EDT enters `connectInfobase` holding the connection's monitor and then asks for that same lock, so the inverted order deadlocks against EDT's background synchronization worker - measured with a thread dump when the same shape ran in the external-object import. All five now run through `underThickClientHandshake`, and its core `handshakeOrder` takes the lock, the release, the work and the reconnection as arguments, so the order is pinned by a test rather than by a live run of one path.
- **An address the model does not hold is named.** `get_project_errors objects=["Document.NoSuchThing"]` matched no marker and answered a clean page, which reads as "this object has no errors". The requested addresses are now asked of `BmExtensionHelper.addressResolves` and the ones the model lacks are named above the markers. That resolver, not the FQN index, is used on purpose: measured on a running EDT, `getTopObjectByFqn` answers `null` for an existing form and an existing template, so reporting from the index alone would deny objects that are there.
- **The request body has a limit.** `readBody` capped nothing. It now counts the bytes it reads and answers `413` past 32 MB. `Content-Length` decides nothing: a request may arrive without it, chunked, or declaring less than it sends. The body also keeps its newlines, which the previous line-joining reader dropped.
- **A javadoc block that documents nothing fails the build.** `scripts/check-orphan-javadoc.py` reports a block with no declaration under it. 63 stand today, 60 of them a block immediately followed by another block; the count may fall and never rise. `scripts/tests/test_check_orphan_javadoc.py` holds the detector both to what it must find and to what it must leave alone.

## Verification

`mvn -f mcp/pom.xml clean verify`: BUILD SUCCESS, 2440 tests. Nine repository checks green, and the detector's own self-test green.

Each guard was proven by putting its defect back: with all three returned, `TheHandshakeHoldsTheLockAroundTheCallAloneTest` failed 5 of 6, `AnAddressTheModelLacksIsNamedTest` failed 2 of 8, `ARequestBodyHasALimitTest` failed 1 and errored 1 - and nothing else in the suite moved. The code was then restored and the suite is green again.
