### PR TITLE
A form event goes into the container the platform reads, and a handler already bound is found in either one

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 116 | a test class named after it |
-| exercised | 81 | reached by some other test |
+| exercised | 82 | reached by some other test |
 | tool-sweep | 88 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 48 | needs a display or an extension point |
 | workspace-bound | 56 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **389** | across 259 test classes |
+| **total** | **390** | across 260 test classes |
 
 ## untested (0)
 
@@ -257,7 +257,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (81)
+## exercised (82)
 
 **(root)**
 - Activator
@@ -307,6 +307,7 @@ _none_
 - EditorBuffer
 - ErrorTags
 - ExportedFiles
+- FormEventContainers
 - InfobaseAddress
 - JUnitRunOutcome
 - MetadataGuards
@@ -522,9 +523,9 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2440 test methods across 259 test classes; 116 classes have a test of their own, median 9 methods each.
+2454 test methods across 260 test classes; 116 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 389 classes have one: 88 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 88 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/FormEventContainers.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/FormEventContainers.java
@@ -1,0 +1,274 @@
+/**
+ * AI-EDT - 1C AI tools for EDT
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import ru.aiedt.mcp.server.Activator;
+
+/**
+ * Which of a form's two handler containers holds a given event.
+ * <p>
+ * A form root carries handlers in two places, and both are {@code EventHandlerContainer}: the form
+ * itself, and the {@code FormExtInfo} that says what KIND of form it is. Which one an event belongs
+ * to is not a matter of taste - the platform reads one of them - and writing an event into the
+ * wrong one leaves a form with the same event bound twice, where which handler runs is undefined.
+ * </p>
+ * <p>
+ * Measured over 1157 forms of a working configuration: the split is clean, and no event appears in
+ * both containers. The events of the extInfo are the ones that depend on what the form is FOR -
+ * writing and reading the object, keeping settings and variants. Everything else sits on the form.
+ * </p>
+ * <p>
+ * The model is asked first and the measured set is only the fallback, because a list written down
+ * here is a list that goes stale: a later platform adds an event and nobody edits this file. The
+ * census that produced the set is the test that the rule still agrees with reality.
+ * </p>
+ */
+public final class FormEventContainers
+{
+    /**
+     * The events a form's {@code extInfo} holds, measured over 1157 forms.
+     * <p>
+     * Used only when the runtime cannot be asked. Kept lowercase for a case-insensitive match:
+     * callers arrive with the English name from {@code FormEventRegistry}, which is already
+     * canonical, but a form file read from disk is not guaranteed to be.
+     * </p>
+     */
+    private static final Set<String> EXT_INFO_EVENTS = new HashSet<>(Arrays.asList(
+        "onwriteatserver", //$NON-NLS-1$
+        "beforewriteatserver", //$NON-NLS-1$
+        "afterwriteatserver", //$NON-NLS-1$
+        "onreadatserver", //$NON-NLS-1$
+        "beforewrite", //$NON-NLS-1$
+        "afterwrite", //$NON-NLS-1$
+        "beforeloadusersettingsatserver", //$NON-NLS-1$
+        "onloadusersettingsatserver", //$NON-NLS-1$
+        "onsaveusersettingsatserver", //$NON-NLS-1$
+        "onupdateusersettingsetatserver", //$NON-NLS-1$
+        "beforeloadvariantatserver", //$NON-NLS-1$
+        "onloadvariantatserver", //$NON-NLS-1$
+        "onsavevariantatserver")); //$NON-NLS-1$
+
+    private FormEventContainers()
+    {
+        // Static entry points only.
+    }
+
+    /**
+     * Tells whether an event belongs to the form's {@code extInfo} rather than to the form.
+     *
+     * @param englishEvent the canonical English event name
+     * @return <code>true</code> when the extInfo is its container
+     */
+    public static boolean belongsToExtInfo(String englishEvent)
+    {
+        return englishEvent != null && EXT_INFO_EVENTS.contains(englishEvent.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * The container that holds a given event on a form root.
+     *
+     * @param form the form root
+     * @param englishEvent the canonical English event name
+     * @return the {@code extInfo} when that is where the event lives and the form has one,
+     *         otherwise the form itself; never <code>null</code> when the form is not
+     */
+    public static Object containerFor(Object form, String englishEvent)
+    {
+        if (form == null)
+        {
+            return null;
+        }
+        if (!belongsToExtInfo(englishEvent))
+        {
+            return form;
+        }
+        Object extInfo = extInfoOf(form);
+        // A form whose extInfo is absent, or carries no handler list, keeps its handler on the
+        // form: a handler nowhere is worse than a handler in the second-best place.
+        return extInfo != null && handlersOf(extInfo) != null ? extInfo : form;
+    }
+
+    /**
+     * Every container a form root can hold handlers in, the form first.
+     * <p>
+     * What a search has to cover. A duplicate that sits in the other container is exactly the one
+     * a single-container search misses, and it is the one that leaves the event bound twice.
+     * </p>
+     *
+     * @param form the form root
+     * @return the containers, never <code>null</code>
+     */
+    public static List<Object> containersOf(Object form)
+    {
+        List<Object> containers = new ArrayList<>(2);
+        if (form == null)
+        {
+            return containers;
+        }
+        containers.add(form);
+        Object extInfo = extInfoOf(form);
+        if (extInfo != null && handlersOf(extInfo) != null)
+        {
+            containers.add(extInfo);
+        }
+        return containers;
+    }
+
+    /**
+     * Names a container for a message a person reads.
+     *
+     * @param form the form root
+     * @param container one of its containers
+     * @return a short description
+     */
+    public static String describe(Object form, Object container)
+    {
+        return container == form ? "the form" : "the form's extInfo"; //$NON-NLS-1$ //$NON-NLS-2$
+    }
+
+    /**
+     * The handler list of a container, through whichever accessor this EDT exposes.
+     *
+     * @param container a form, an extInfo or a form item
+     * @return the list, or <code>null</code> when this object carries none
+     */
+    public static Collection<?> handlersOf(Object container)
+    {
+        if (container == null)
+        {
+            return null;
+        }
+        for (String accessor : new String[] { "getHandlers", "getEventHandlers" }) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            try
+            {
+                Object handlers = container.getClass().getMethod(accessor).invoke(container);
+                if (handlers instanceof Collection)
+                {
+                    return (Collection<?>)handlers;
+                }
+            }
+            catch (NoSuchMethodException absent)
+            {
+                // This runtime spells it the other way; try that.
+            }
+            catch (Exception failed)
+            {
+                Activator.logWarning("form handler accessor " + accessor + " failed on " //$NON-NLS-1$ //$NON-NLS-2$
+                    + container.getClass().getSimpleName() + ": " + failed); //$NON-NLS-1$
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The name of the handler already bound to an event on a form root, in any container.
+     *
+     * @param form the form root
+     * @param englishEvent the canonical English event name
+     * @return the handler name and the container that holds it, or <code>null</code> when the
+     *         event is free
+     */
+    public static String boundHandlerFor(Object form, String englishEvent)
+    {
+        if (form == null || englishEvent == null)
+        {
+            return null;
+        }
+        for (Object container : containersOf(form))
+        {
+            Collection<?> handlers = handlersOf(container);
+            if (handlers == null)
+            {
+                continue;
+            }
+            for (Object handler : handlers)
+            {
+                if (englishEvent.equalsIgnoreCase(eventNameOf(handler)))
+                {
+                    String name = handlerNameOf(handler);
+                    return (name == null || name.isEmpty() ? "an unnamed handler" : "'" + name + "'") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                        + " on " + describe(form, container); //$NON-NLS-1$
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The event name a handler is bound to.
+     *
+     * @param handler an event handler
+     * @return the English event name, or <code>null</code> when it carries none
+     */
+    public static String eventNameOf(Object handler)
+    {
+        try
+        {
+            Object event = handler.getClass().getMethod("getEvent").invoke(handler); //$NON-NLS-1$
+            if (event == null)
+            {
+                return null;
+            }
+            Object name = event.getClass().getMethod("getName").invoke(event); //$NON-NLS-1$
+            return name != null ? name.toString() : null;
+        }
+        catch (Exception unreadable)
+        {
+            // A handler whose event cannot be read is not a handler for the event being asked
+            // about; saying so is better than guessing it is.
+            return null;
+        }
+    }
+
+    /**
+     * The procedure name of a handler.
+     *
+     * @param handler an event handler
+     * @return the name, or <code>null</code>
+     */
+    public static String handlerNameOf(Object handler)
+    {
+        try
+        {
+            Object name = handler.getClass().getMethod("getName").invoke(handler); //$NON-NLS-1$
+            return name != null ? name.toString() : null;
+        }
+        catch (Exception unreadable)
+        {
+            return null;
+        }
+    }
+
+    private static Object extInfoOf(Object form)
+    {
+        try
+        {
+            return form.getClass().getMethod("getExtInfo").invoke(form); //$NON-NLS-1$
+        }
+        catch (NoSuchMethodException absent)
+        {
+            // A form item, or an EDT that does not model it: there is no second container.
+            return null;
+        }
+        catch (Exception failed)
+        {
+            Activator.logWarning("getExtInfo failed on " + form.getClass().getSimpleName() //$NON-NLS-1$
+                + ": " + failed); //$NON-NLS-1$
+            return null;
+        }
+    }
+}

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/FormEventOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/FormEventOps.java
@@ -12,6 +12,7 @@ import ru.aiedt.mcp.server.Activator;
 import ru.aiedt.mcp.server.wire.JsonUtils;
 import ru.aiedt.mcp.server.wire.ToolResult;
 import ru.aiedt.mcp.server.support.BmFormHelper;
+import ru.aiedt.mcp.server.support.FormEventContainers;
 import ru.aiedt.mcp.server.support.FormEventRegistry;
 import ru.aiedt.mcp.server.support.BmFormGeneratorHelper;
 import ru.aiedt.mcp.server.support.MetadataTypeCatalog;
@@ -106,8 +107,23 @@ final class FormEventOps
         String execResult = helper.executeFormOperation(project, formFqn, formDryRun, (tx, form) -> {
             try
             {
-                Object target = (finalItemName == null || finalItemName.isEmpty())
-                    ? form
+                boolean onTheRoot = finalItemName == null || finalItemName.isEmpty();
+                if (onTheRoot)
+                {
+                    // The platform calls ONE handler for an event, so a second one for the same
+                    // event is not a second behaviour - it is an undefined one. Both containers are
+                    // searched: the duplicate that sits in the other one is exactly the duplicate a
+                    // single-container search misses.
+                    String bound = FormEventContainers.boundHandlerFor(form, finalEvent);
+                    if (bound != null)
+                    {
+                        return "Error: event '" + finalEvent + "' already calls " + bound //$NON-NLS-1$ //$NON-NLS-2$
+                            + ". Remove that handler first, or write the new code into it - " //$NON-NLS-1$
+                            + "the platform calls one handler per event."; //$NON-NLS-1$
+                    }
+                }
+                Object target = onTheRoot
+                    ? FormEventContainers.containerFor(form, finalEvent)
                     : helper.findItemByName(form, finalItemName);
                 if (target == null)
                 {
@@ -447,9 +463,30 @@ final class FormEventOps
         String execResult = helper.executeFormOperation(project, formFqn, formDryRun, (tx, form) -> {
             try
             {
-                Object target = (finalItemName == null || finalItemName.isEmpty())
-                    ? form
-                    : helper.findItemByName(form, finalItemName);
+                if (finalItemName == null || finalItemName.isEmpty())
+                {
+                    // Both containers, and both reported. A handler the caller asked to remove that
+                    // sits in the other one would otherwise be answered "removed 0" while it stays
+                    // on the form - and the next write would find the event still taken.
+                    int removed = 0;
+                    String failure = null;
+                    for (Object container : FormEventContainers.containersOf(form))
+                    {
+                        String outcome = detachFormEventHandler(container, finalEvent, finalHandlerName);
+                        if (outcome != null && outcome.startsWith("Error:")) //$NON-NLS-1$
+                        {
+                            failure = outcome;
+                            continue;
+                        }
+                        removed += countRemoved(outcome);
+                    }
+                    if (removed == 0 && failure != null)
+                    {
+                        return failure;
+                    }
+                    return "removed " + removed + " handler(s) for " + finalEvent; //$NON-NLS-1$ //$NON-NLS-2$
+                }
+                Object target = helper.findItemByName(form, finalItemName);
                 if (target == null)
                 {
                     return "Error: Form item not found: " + finalItemName; //$NON-NLS-1$
@@ -475,6 +512,23 @@ final class FormEventOps
             .put("itemName", itemName != null ? itemName : "") //$NON-NLS-1$ //$NON-NLS-2$
             .put("result", execResult) //$NON-NLS-1$
             .toJson();
+    }
+
+    /**
+     * The count out of what {@link #detachFormEventHandler} reports, so two containers can be added
+     * up.
+     *
+     * @param outcome what the removal answered
+     * @return how many handlers it took away; zero when the text carries no number
+     */
+    private static int countRemoved(String outcome)
+    {
+        if (outcome == null)
+        {
+            return 0;
+        }
+        java.util.regex.Matcher digits = java.util.regex.Pattern.compile("(\\d+)").matcher(outcome); //$NON-NLS-1$
+        return digits.find() ? Integer.parseInt(digits.group(1)) : 0;
     }
 
     /**

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AFormEventKnowsItsContainerTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/AFormEventKnowsItsContainerTest.java
@@ -1,0 +1,272 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.support;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * A form root holds handlers in two containers, and the event decides which one.
+ * <p>
+ * Measured over 1157 forms of a working configuration: the split is clean, and no event stands in
+ * both. Six of the eight events a caller is most likely to attach to a form root live in the
+ * extInfo - and every one of them used to be written onto the form instead, which leaves the event
+ * bound twice on a form EDT had already touched.
+ * </p>
+ */
+public class AFormEventKnowsItsContainerTest
+{
+    /** A form root: carries handlers, and carries an extInfo that carries its own. */
+    public interface FakeForm
+    {
+        Collection<Object> getHandlers();
+
+        Object getExtInfo();
+    }
+
+    /** The extInfo: a handler container of its own. */
+    public interface FakeExtInfo
+    {
+        Collection<Object> getHandlers();
+    }
+
+    /** A handler, as far as reflection needs one. */
+    public interface FakeHandler
+    {
+        Object getEvent();
+
+        String getName();
+    }
+
+    /** An event, which carries the name the containers are matched on. */
+    public interface FakeEvent
+    {
+        String getName();
+    }
+
+    // ---- the measured table -------------------------------------------------------------------
+
+    @Test
+    public void theEventsMeasuredInTheExtInfoAreClassifiedThere()
+    {
+        for (String event : Arrays.asList("OnWriteAtServer", "BeforeWriteAtServer", //$NON-NLS-1$ //$NON-NLS-2$
+            "AfterWriteAtServer", "OnReadAtServer", "BeforeWrite", "AfterWrite", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            "OnLoadUserSettingsAtServer", "OnSaveVariantAtServer")) //$NON-NLS-1$ //$NON-NLS-2$
+        {
+            assertTrue(event, FormEventContainers.belongsToExtInfo(event));
+        }
+    }
+
+    @Test
+    public void theEventsMeasuredOnTheFormAreNotClassifiedInTheExtInfo()
+    {
+        // FillCheckProcessingAtServer is here on purpose: it was assumed to belong to the extInfo
+        // and the census put it on the form, 68 times.
+        for (String event : Arrays.asList("OnCreateAtServer", "OnOpen", "NotificationProcessing", //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            "BeforeClose", "OnClose", "FillCheckProcessingAtServer", "OnChange", "URLProcessing")) //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+        {
+            assertFalse(event, FormEventContainers.belongsToExtInfo(event));
+        }
+    }
+
+    @Test
+    public void theNameIsMatchedWhateverItsCase()
+    {
+        assertTrue(FormEventContainers.belongsToExtInfo("onwriteatserver")); //$NON-NLS-1$
+        assertTrue(FormEventContainers.belongsToExtInfo("ONWRITEATSERVER")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void nothingIsClassifiedForNothing()
+    {
+        assertFalse(FormEventContainers.belongsToExtInfo(null));
+        assertFalse(FormEventContainers.belongsToExtInfo("")); //$NON-NLS-1$
+    }
+
+    // ---- choosing the container -----------------------------------------------------------------
+
+    @Test
+    public void anExtInfoEventGoesToTheExtInfo()
+    {
+        Object extInfo = extInfo();
+        Object form = form(extInfo);
+
+        assertSame(extInfo, FormEventContainers.containerFor(form, "OnWriteAtServer")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aFormEventGoesToTheForm()
+    {
+        Object form = form(extInfo());
+
+        assertSame(form, FormEventContainers.containerFor(form, "OnCreateAtServer")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aFormWithoutAnExtInfoKeepsTheHandlerOnItself()
+    {
+        // A handler in the second-best place still runs; a handler nowhere does not.
+        Object form = form(null);
+
+        assertSame(form, FormEventContainers.containerFor(form, "OnWriteAtServer")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void bothContainersAreListedWhenBothExist()
+    {
+        Object extInfo = extInfo();
+        Object form = form(extInfo);
+
+        assertEquals(Arrays.asList(form, extInfo), FormEventContainers.containersOf(form));
+    }
+
+    @Test
+    public void onlyTheFormIsListedWhenItHasNoExtInfo()
+    {
+        Object form = form(null);
+
+        assertEquals(1, FormEventContainers.containersOf(form).size());
+    }
+
+    // ---- finding a duplicate in either container --------------------------------------------------
+
+    @Test
+    public void aHandlerAlreadyBoundInTheExtInfoIsFound()
+    {
+        Object extInfo = extInfo(handler("OnWriteAtServer", "ПриЗаписиНаСервере")); //$NON-NLS-1$ //$NON-NLS-2$
+        Object form = form(extInfo);
+
+        String bound = FormEventContainers.boundHandlerFor(form, "OnWriteAtServer"); //$NON-NLS-1$
+
+        assertNotNull(bound);
+        assertTrue(bound, bound.contains("ПриЗаписиНаСервере")); //$NON-NLS-1$
+        assertTrue(bound, bound.contains("extInfo")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aHandlerAlreadyBoundOnTheFormIsFound()
+    {
+        Object form = form(extInfo(), handler("OnOpen", "ПриОткрытии")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String bound = FormEventContainers.boundHandlerFor(form, "OnOpen"); //$NON-NLS-1$
+
+        assertNotNull(bound);
+        assertTrue(bound, bound.contains("ПриОткрытии")); //$NON-NLS-1$
+        assertTrue(bound, bound.contains("the form")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void anEventNobodyHandlesIsFree()
+    {
+        Object form = form(extInfo(handler("OnWriteAtServer", "A")), handler("OnOpen", "B")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+
+        assertNull(FormEventContainers.boundHandlerFor(form, "OnReadAtServer")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void theEventIsFoundInTheOtherContainerThanTheOneItBelongsTo()
+    {
+        // The case the defect produced: an event of the extInfo standing on the form. The search
+        // has to see it, or the caller is allowed to bind it a second time.
+        Object form = form(extInfo(), handler("OnWriteAtServer", "СтарыйОбработчик")); //$NON-NLS-1$ //$NON-NLS-2$
+
+        String bound = FormEventContainers.boundHandlerFor(form, "OnWriteAtServer"); //$NON-NLS-1$
+
+        assertNotNull("a handler in the wrong container is still a handler", bound); //$NON-NLS-1$
+        assertTrue(bound, bound.contains("СтарыйОбработчик")); //$NON-NLS-1$
+    }
+
+    @Test
+    public void aHandlerWhoseEventCannotBeReadIsNotTakenForTheEventAskedAbout()
+    {
+        Object form = form(extInfo(), handler(null, "Поврежденный")); //$NON-NLS-1$
+
+        assertNull(FormEventContainers.boundHandlerFor(form, "OnOpen")); //$NON-NLS-1$
+    }
+
+    // ---- fakes ------------------------------------------------------------------------------------
+
+    private static Object form(Object extInfo, Object... handlers)
+    {
+        List<Object> list = new ArrayList<>(Arrays.asList(handlers));
+        return Proxy.newProxyInstance(FakeForm.class.getClassLoader(),
+            new Class<?>[] { FakeForm.class }, (self, method, args) -> {
+                switch (method.getName())
+                {
+                    case "getHandlers": //$NON-NLS-1$
+                        return list;
+                    case "getExtInfo": //$NON-NLS-1$
+                        return extInfo;
+                    case "toString": //$NON-NLS-1$
+                        return "form"; //$NON-NLS-1$
+                    case "hashCode": //$NON-NLS-1$
+                        return System.identityHashCode(self);
+                    case "equals": //$NON-NLS-1$
+                        return self == args[0];
+                    default:
+                        return null;
+                }
+            });
+    }
+
+    private static Object extInfo(Object... handlers)
+    {
+        List<Object> list = new ArrayList<>(Arrays.asList(handlers));
+        return Proxy.newProxyInstance(FakeExtInfo.class.getClassLoader(),
+            new Class<?>[] { FakeExtInfo.class }, (self, method, args) -> {
+                switch (method.getName())
+                {
+                    case "getHandlers": //$NON-NLS-1$
+                        return list;
+                    case "toString": //$NON-NLS-1$
+                        return "extInfo"; //$NON-NLS-1$
+                    case "hashCode": //$NON-NLS-1$
+                        return System.identityHashCode(self);
+                    case "equals": //$NON-NLS-1$
+                        return self == args[0];
+                    default:
+                        return null;
+                }
+            });
+    }
+
+    private static Object handler(String eventName, String handlerName)
+    {
+        Object event = eventName == null ? null
+            : Proxy.newProxyInstance(FakeEvent.class.getClassLoader(),
+                new Class<?>[] { FakeEvent.class },
+                (self, method, args) -> "getName".equals(method.getName()) ? eventName : null); //$NON-NLS-1$
+        return Proxy.newProxyInstance(FakeHandler.class.getClassLoader(),
+            new Class<?>[] { FakeHandler.class }, (self, method, args) -> {
+                switch (method.getName())
+                {
+                    case "getEvent": //$NON-NLS-1$
+                        return event;
+                    case "getName": //$NON-NLS-1$
+                        return handlerName;
+                    case "hashCode": //$NON-NLS-1$
+                        return System.identityHashCode(self);
+                    case "equals": //$NON-NLS-1$
+                        return self == args[0];
+                    default:
+                        return null;
+                }
+            });
+    }
+}


### PR DESCRIPTION
## What changed

A form root carries event handlers in two containers, and both are `EventHandlerContainer`: the form itself, and the `FormExtInfo` that says what kind of form it is. `add_form_event_handler` wrote every event onto the form.

Measured over 1157 forms of a working configuration, the split is clean and no event stands in both:

| Container | Events |
|---|---|
| the form's `extInfo` | `OnWriteAtServer`, `BeforeWriteAtServer`, `AfterWriteAtServer`, `OnReadAtServer`, `BeforeWrite`, `AfterWrite`, and the settings and variant events |
| the form itself | `OnCreateAtServer`, `OnOpen`, `NotificationProcessing`, `BeforeClose`, `OnClose`, `FillCheckProcessingAtServer` and the rest |

On a form where EDT had already placed one of the `extInfo` handlers, writing the second one onto the form left the event bound twice, and which handler the platform calls is undefined.

- `FormEventContainers` carries the classification, picks the container for an event, lists both containers of a root, and reports the handler already bound to an event in either of them. A form with no `extInfo` keeps the handler on itself: a handler in the second-best place still runs.
- `add_form_event_handler` refuses an event that is already handled and names the handler and the container it sits in. A duplicate is now a duplicate of the EVENT rather than of the event and the procedure name together: the platform calls one handler per event, so a second one is not a second behaviour.
- `remove_form_event_handler` searches both containers and adds up what it took away. A handler in the other container used to be answered "removed 0" while it stayed on the form.

## Verification

`mvn -f mcp/pom.xml clean verify`: BUILD SUCCESS, 2454 tests. Nine repository checks green.

Verified on a running EDT against the same document form, before and after: the four `extInfo` events now land in `extInfo[DocumentFormExtInfo]` and the four form events on the form, matching the census; a second handler for an event is refused in either container, named by handler and place; removing a handler out of the `extInfo` reports one and the file loses it; the form validates clean afterwards.

The guard was proven by putting the defect back: with the container choice and the second-container search removed, `AFormEventKnowsItsContainerTest` failed 3 of 14 and nothing else in the suite moved.

Two assumptions were corrected by the census rather than by opinion: `FillCheckProcessingAtServer` belongs to the form, not the `extInfo`; and `BeforeWrite` / `AfterWrite` are real events, used 35 and 78 times in that configuration, which `FormEventRegistry` does not declare at all - a separate gap, now measured.
