### PR TITLE
Declare the two write events a form actually carries

### DIFF
--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/FormEventRegistry.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/FormEventRegistry.java
@@ -84,6 +84,13 @@ public final class FormEventRegistry
         // Form root - lifecycle on the client.
         register(m, "OnOpen", "ПриОткрытии", //$NON-NLS-1$ //$NON-NLS-2$
             "Отказ", "&НаКлиенте", Scope.FORM); //$NON-NLS-1$ //$NON-NLS-2$
+        // Measured across 1094 form modules of a working configuration: ПослеЗаписи(ПараметрыЗаписи)
+        // 78 times and ПередЗаписью(Отказ, ПараметрыЗаписи) 34. Both were missing here, so a caller
+        // naming either was refused before the handler could be placed at all.
+        register(m, "BeforeWrite", "ПередЗаписью", //$NON-NLS-1$ //$NON-NLS-2$
+            "Отказ, ПараметрыЗаписи", "&НаКлиенте", Scope.FORM); //$NON-NLS-1$ //$NON-NLS-2$
+        register(m, "AfterWrite", "ПослеЗаписи", //$NON-NLS-1$ //$NON-NLS-2$
+            "ПараметрыЗаписи", "&НаКлиенте", Scope.FORM); //$NON-NLS-1$ //$NON-NLS-2$
         register(m, "BeforeClose", "ПередЗакрытием", //$NON-NLS-1$ //$NON-NLS-2$
             "Отказ, ЗавершениеРаботы, ТекстПредупреждения, СтандартнаяОбработка", //$NON-NLS-1$
             "&НаКлиенте", Scope.FORM); //$NON-NLS-1$

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/FormEventRegistryTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/FormEventRegistryTest.java
@@ -133,4 +133,26 @@ public class FormEventRegistryTest
         assertTrue(spec.signature,
             spec.signature.contains("СтандартнаяОбработка")); //$NON-NLS-1$
     }
+
+    @Test
+    public void theWriteEventsOfTheFormAreDeclared()
+    {
+        // Measured across 1094 form modules of a working configuration: ПослеЗаписи 78 times and
+        // ПередЗаписью 34. Neither was declared here, so naming either was refused before the
+        // handler could be placed at all - while the forms of that same configuration carry them.
+        EventSpec before = FormEventRegistry.lookup("BeforeWrite"); //$NON-NLS-1$
+        EventSpec after = FormEventRegistry.lookup("AfterWrite"); //$NON-NLS-1$
+
+        assertNotNull("BeforeWrite has to resolve", before); //$NON-NLS-1$
+        assertNotNull("AfterWrite has to resolve", after); //$NON-NLS-1$
+        assertSame(before, FormEventRegistry.lookup("ПередЗаписью")); //$NON-NLS-1$
+        assertSame(after, FormEventRegistry.lookup("ПослеЗаписи")); //$NON-NLS-1$
+
+        // Client-side, and they are not the AtServer events of the same name.
+        assertTrue(before.directive, before.directive.contains("НаКлиенте")); //$NON-NLS-1$
+        assertTrue(after.directive, after.directive.contains("НаКлиенте")); //$NON-NLS-1$
+        assertTrue(before.signature, before.signature.contains("Отказ")); //$NON-NLS-1$
+        assertTrue(before.signature, before.signature.contains("ПараметрыЗаписи")); //$NON-NLS-1$
+        assertEquals("ПараметрыЗаписи", after.signature); //$NON-NLS-1$
+    }
 }


### PR DESCRIPTION
`FormEventRegistry` knew neither `BeforeWrite` nor `AfterWrite`, so a caller naming either was refused before the handler could be placed at all - while the forms of a working configuration carry both.

Measured, not assumed:

| event | in form modules | as handlers on forms |
|---|---|---|
| `ПослеЗаписи(ПараметрыЗаписи)` | 78 | 78 |
| `ПередЗаписью(Отказ, ПараметрыЗаписи)` | 34 | 35 |

across 1094 form modules and 1157 forms of the same configuration. Both are client-side, and both belong to the form's `extInfo` - which the container rule already knew, while the registry refused to let anything reach it.

`ПередЗаписью(Отказ, РежимЗаписи, РежимПроведения)` appears once in that corpus and is the object module's event of the same name, not the form's; it is not registered here.

`mvn -f mcp/pom.xml clean verify`: BUILD SUCCESS, 2458 tests, `FormEventRegistryTest` 11 of 11.