### PR TITLE
Return 57 javadoc blocks to the members they document

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -523,7 +523,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2457 test methods across 261 test classes; 116 classes have a test of their own, median 9 methods each.
+2458 test methods across 261 test classes; 116 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 88 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/folders/repository/YamlClusterStore.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/folders/repository/YamlClusterStore.java
@@ -748,17 +748,6 @@ public class YamlClusterStore
 
 
 
-    /**
-
-     * Returns the project's clusters file handle.
-
-     *
-
-     * @param project the project
-
-     * @return the file handle, whether or not it exists
-
-     */
 
     /**
      * @param project the project whose settings folder is wanted
@@ -770,6 +759,17 @@ public class YamlClusterStore
         return location == null ? null : location.toFile().toPath();
     }
 
+    /**
+
+     * Returns the project's clusters file handle.
+
+     *
+
+     * @param project the project
+
+     * @return the file handle, whether or not it exists
+
+     */
     private static IFile clustersFile(IProject project)
 
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmComparisonHelper.java
@@ -203,14 +203,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Which changed objects a caller wants named, and which page of them.
-     * <p>
-     * The counts are always over everything: filtering narrows what is listed, never what is
-     * counted. A census that shrank with the page would understate the update, and understating it
-     * is the one thing these numbers must not do.
-     * </p>
-     */
-    /**
      * Everything one comparison is asked to do.
      * <p>
      * <b>Eleven positional parameters were as far as that could go.</b> Six of them were strings
@@ -287,6 +279,14 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Which changed objects a caller wants named, and which page of them.
+     * <p>
+     * The counts are always over everything: filtering narrows what is listed, never what is
+     * counted. A census that shrank with the page would understate the update, and understating it
+     * is the one thing these numbers must not do.
+     * </p>
+     */
     public static final class Page
     {
         /** Report only objects with this attribution; every attribution when null. */
@@ -301,7 +301,6 @@ public final class BmComparisonHelper
         /** Report only objects the environment says must take part in a merge. */
         public boolean mustBeMergedOnly;
 
-        /** How many matching objects to skip. */
         /**
          * Look inside modules, so a change can be named by the piece of the module it is in.
          * <p>
@@ -312,6 +311,7 @@ public final class BmComparisonHelper
          */
         public boolean methodLevel;
 
+        /** How many matching objects to skip. */
         public int offset;
 
         /** How many to name, capped at {@link #PAGE_LIMIT}. */
@@ -1371,16 +1371,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Closes every comparison this server still has open.
-     * <p>
-     * For plugin stop. A comparison that outlives the server holds the comparison store of the
-     * environment, and the environment then waits on a transaction whose owner is gone - measured
-     * as an EDT sitting at no load for the better part of an hour, unable to shut down.
-     * </p>
-     *
-     * @return how many were closed
-     */
-    /**
      * Closes comparisons that have gone idle, without waiting for another comparison to ask.
      * <p>
      * <b>Expiry used to run only as a side effect of the next call.</b> A caller who took one
@@ -1434,6 +1424,16 @@ public final class BmComparisonHelper
         return closed;
     }
 
+    /**
+     * Closes every comparison this server still has open.
+     * <p>
+     * For plugin stop. A comparison that outlives the server holds the comparison store of the
+     * environment, and the environment then waits on a transaction whose owner is gone - measured
+     * as an EDT sitting at no load for the better part of an hour, unable to shut down.
+     * </p>
+     *
+     * @return how many were closed
+     */
     public static int closeEverything()
     {
         int closed = 0;
@@ -1461,23 +1461,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Builds the settings the comparison runs under, restoring saved decisions when asked.
-     * <p>
-     * This closes the circle the settings file opened. Writing decisions out is only half of
-     * handing work to a person: they open the file in EDT, decide the hard objects by eye, save,
-     * and the decisions then have to come back. The environment restores both halves of that file
-     * - the rules and the correspondences somebody established by hand between objects that do not
-     * match by uuid or name - and losing the second half would silently discard the most expensive
-     * part of their work.
-     * </p>
-     *
-     * @param manager the comparison service.
-     * @param handle the process, already built.
-     * @param decisionsFrom path to a saved settings file, or <code>null</code> for none.
-     * @param outcome the answer being built.
-     * @return the settings, or <code>null</code> when the file was named and could not be read
-     */
-    /**
      * Starts the settings for a comparison, with the one switch that changes what the tree holds.
      * <p>
      * {@code parseBslModuleStructure} makes the environment look inside modules instead of treating
@@ -1495,6 +1478,23 @@ public final class BmComparisonHelper
             MatchingStrategy.UUID_THEN_NAME).parseBslModuleStructure(outcome.sectionsWanted);
     }
 
+    /**
+     * Builds the settings the comparison runs under, restoring saved decisions when asked.
+     * <p>
+     * This closes the circle the settings file opened. Writing decisions out is only half of
+     * handing work to a person: they open the file in EDT, decide the hard objects by eye, save,
+     * and the decisions then have to come back. The environment restores both halves of that file
+     * - the rules and the correspondences somebody established by hand between objects that do not
+     * match by uuid or name - and losing the second half would silently discard the most expensive
+     * part of their work.
+     * </p>
+     *
+     * @param manager the comparison service.
+     * @param handle the process, already built.
+     * @param decisionsFrom path to a saved settings file, or <code>null</code> for none.
+     * @param outcome the answer being built.
+     * @return the settings, or <code>null</code> when the file was named and could not be read
+     */
     private static ComparisonProcessSettings settingsFor(IComparisonManager manager,
         ComparisonProcessHandle handle, String decisionsFrom, Outcome outcome)
     {
@@ -2260,19 +2260,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Writes the pre-merge snapshot into the project, where a restore can find it.
-     * <p>
-     * Beside the plugin's other project state in {@code .settings}, and stamped with the time so a
-     * second merge cannot overwrite the record of what the first one found. The file is the only
-     * thing that makes the loss reversible, so failing to write it is reported in the answer rather
-     * than logged and forgotten.
-     * </p>
-     *
-     * @param projectName the project.
-     * @param snapshot what was taken; may be <code>null</code> when there was nothing to take.
-     * @param outcome where to record the path or the reason there is none.
-     */
-    /**
      * Whether a refusal to snapshot means the project simply is not on support.
      *
      * @param cannotTell what the snapshot said.
@@ -2283,16 +2270,6 @@ public final class BmComparisonHelper
         return cannotTell != null && cannotTell.contains("is not on support"); //$NON-NLS-1$
     }
 
-    /**
-     * The platform version a project declares, read from the file that carries it.
-     * <p>
-     * Read from {@code DT-INF/PROJECT.PMF} rather than asked of the environment, because what has
-     * to be compared is the value on disk before and after - the environment answers only for now.
-     * </p>
-     *
-     * @param projectName the project.
-     * @return the version, or <code>null</code> when the file will not say
-     */
     /**
      * Which of the objects both sides changed still held something of ours, before the merge ran.
      * <p>
@@ -2540,6 +2517,16 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * The platform version a project declares, read from the file that carries it.
+     * <p>
+     * Read from {@code DT-INF/PROJECT.PMF} rather than asked of the environment, because what has
+     * to be compared is the value on disk before and after - the environment answers only for now.
+     * </p>
+     *
+     * @param projectName the project.
+     * @return the version, or <code>null</code> when the file will not say
+     */
     private static String runtimeVersionOf(String projectName)
     {
         try
@@ -2583,31 +2570,6 @@ public final class BmComparisonHelper
         outcome.runtimeVersionAfter = after;
     }
 
-    /**
-     * Removes the support snapshot when the merge it was taken for never wrote anything.
-     * <p>
-     * <b>Measured: a refused merge left 976 KB in the project, and three of those accumulated in a
-     * day.</b> The snapshot is taken before the merge is attempted, and several refusals come
-     * later - no decisions to apply, objects that could not be held back, the protection list past
-     * its limit. Each of those wrote nothing at all, so the file records a state that is still the
-     * current one and can be taken again whenever it is wanted. Beside the code that writes it
-     * stands its own rule: reporting must leave no trace.
-     * </p>
-     * <p>
-     * <b>The test is not whether the merge was refused but whether writing could have begun.</b>
-     * Past {@link Outcome#writeMayHaveStarted} the file may be the only way back, and it is kept -
-     * including after a timeout or an exception, where what happened is simply not known. An
-     * unknown state is treated as written: a stray megabyte costs disk, a missing snapshot costs
-     * the support model.
-     * </p>
-     * <p>
-     * Only this call's own file is touched, and only the one whose path this call recorded. When
-     * the delete fails the path stays in the answer and says why, because an answer naming a file
-     * that is not there is worse than one naming a file nobody needs.
-     * </p>
-     *
-     * @param outcome the answer being built; its snapshot path is cleared when the file goes
-     */
     // Package-visible for the test: the decision it makes is what stands between a stray megabyte
     // and a lost support model, and it is reachable no other way without running a real merge.
     /**
@@ -2661,6 +2623,31 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Removes the support snapshot when the merge it was taken for never wrote anything.
+     * <p>
+     * <b>Measured: a refused merge left 976 KB in the project, and three of those accumulated in a
+     * day.</b> The snapshot is taken before the merge is attempted, and several refusals come
+     * later - no decisions to apply, objects that could not be held back, the protection list past
+     * its limit. Each of those wrote nothing at all, so the file records a state that is still the
+     * current one and can be taken again whenever it is wanted. Beside the code that writes it
+     * stands its own rule: reporting must leave no trace.
+     * </p>
+     * <p>
+     * <b>The test is not whether the merge was refused but whether writing could have begun.</b>
+     * Past {@link Outcome#writeMayHaveStarted} the file may be the only way back, and it is kept -
+     * including after a timeout or an exception, where what happened is simply not known. An
+     * unknown state is treated as written: a stray megabyte costs disk, a missing snapshot costs
+     * the support model.
+     * </p>
+     * <p>
+     * Only this call's own file is touched, and only the one whose path this call recorded. When
+     * the delete fails the path stays in the answer and says why, because an answer naming a file
+     * that is not there is worse than one naming a file nobody needs.
+     * </p>
+     *
+     * @param outcome the answer being built; its snapshot path is cleared when the file goes
+     */
     static void dropSnapshotNothingNeeds(Outcome outcome)
     {
         if (outcome.supportSnapshotFile == null || outcome.mergeRefused == null)
@@ -2688,6 +2675,19 @@ public final class BmComparisonHelper
 
     // Package-visible for the test: it is the gate that decides whether an irreversible merge may
     // go ahead, and reaching it any other way means running a real merge against a real project.
+    /**
+     * Writes the pre-merge snapshot into the project, where a restore can find it.
+     * <p>
+     * Beside the plugin's other project state in {@code .settings}, and stamped with the time so a
+     * second merge cannot overwrite the record of what the first one found. The file is the only
+     * thing that makes the loss reversible, so failing to write it is reported in the answer rather
+     * than logged and forgotten.
+     * </p>
+     *
+     * @param projectName the project.
+     * @param snapshot what was taken; may be <code>null</code> when there was nothing to take.
+     * @param outcome where to record the path or the reason there is none.
+     */
     static void keepSnapshot(String projectName, SupportSnapshot snapshot, Outcome outcome)
     {
         if (snapshot != null && snapshot.cannotTell != null)
@@ -2864,12 +2864,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * The merge rule of that name, or <code>null</code>.
-     *
-     * @param name what the caller wrote.
-     * @return the rule
-     */
-    /**
      * Says why a rule cannot be carried out from here.
      * <p>
      * <b>Measured on a stand, and only one of the two suspects is guilty.</b> On a node the
@@ -2901,6 +2895,12 @@ public final class BmComparisonHelper
             + "EDT."; //$NON-NLS-1$
     }
 
+    /**
+     * The merge rule of that name, or <code>null</code>.
+     *
+     * @param name what the caller wrote.
+     * @return the rule
+     */
     private static MergeRule ruleNamed(String name)
     {
         if (name == null)
@@ -3081,24 +3081,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Puts one object both sides changed under the delivery, keeping what only we have.
-     * <p>
-     * The rule was measured before it was chosen: on a module node
-     * {@link MergeRule#MERGE_PRIORITIZING_OTHER} resolves lines both sides touched toward the
-     * delivery and leaves methods the delivery does not carry in place. That is what an update
-     * with customisations preserved has to mean; holding the object instead means the delivery is
-     * never applied to anything anybody has worked on.
-     * </p>
-     * <p>
-     * <b>A node that will not take the rule is held and named.</b> Falling back quietly would
-     * restore the old behaviour object by object, and the answer would still say the update ran.
-     * </p>
-     *
-     * @param session the comparison.
-     * @param nodeId the node both sides changed.
-     * @param outcome where to record what was done and what was not
-     */
-    /**
      * Holds an object both sides changed, because at this granularity nothing can promise the work
      * on this side will survive being merged.
      * <p>
@@ -3157,6 +3139,24 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Puts one object both sides changed under the delivery, keeping what only we have.
+     * <p>
+     * The rule was measured before it was chosen: on a module node
+     * {@link MergeRule#MERGE_PRIORITIZING_OTHER} resolves lines both sides touched toward the
+     * delivery and leaves methods the delivery does not carry in place. That is what an update
+     * with customisations preserved has to mean; holding the object instead means the delivery is
+     * never applied to anything anybody has worked on.
+     * </p>
+     * <p>
+     * <b>A node that will not take the rule is held and named.</b> Falling back quietly would
+     * restore the old behaviour object by object, and the answer would still say the update ran.
+     * </p>
+     *
+     * @param session the comparison.
+     * @param nodeId the node both sides changed.
+     * @param outcome where to record what was done and what was not
+     */
     private static void mergeWithDeliveryInFront(IComparisonSession session, Long nodeId,
         Outcome outcome)
     {
@@ -3372,6 +3372,26 @@ public final class BmComparisonHelper
     }
 
     /**
+     * Whether a merge was started and has not been seen to reach a terminal state.
+     * <p>
+     * The wait has a limit and a merge can outlive it. Treating that as finished stopped the
+     * handle mid-write, which is the one thing an irreversible operation must not have done to it
+     * from the outside.
+     * </p>
+     *
+     * @param outcome what the run recorded.
+     * @return <code>true</code> when a merge is, as far as this call knows, still going
+     */
+    private static boolean mergeStillRunning(Outcome outcome)
+    {
+        String status = outcome.mergeStatus;
+        return status != null
+            && !status.equals(ComparisonProcessStatus.MERGE_PROCESS_FINISHED.name())
+            && !status.equals(ComparisonProcessStatus.MERGE_PROCESS_DISCARDED.name())
+            && !status.equals(ComparisonProcessStatus.COMPARISON_MERGE_PROCESS_CANCELLED.name());
+    }
+
+    /**
      * Waits for a started merge to end, and reports what the environment actually did.
      * <p>
      * Three ends are distinguished, because they mean entirely different things to whoever asked:
@@ -3397,26 +3417,6 @@ public final class BmComparisonHelper
      * @param outcome the answer being built.
      * @throws InterruptedException when the wait is interrupted
      */
-    /**
-     * Whether a merge was started and has not been seen to reach a terminal state.
-     * <p>
-     * The wait has a limit and a merge can outlive it. Treating that as finished stopped the
-     * handle mid-write, which is the one thing an irreversible operation must not have done to it
-     * from the outside.
-     * </p>
-     *
-     * @param outcome what the run recorded.
-     * @return <code>true</code> when a merge is, as far as this call knows, still going
-     */
-    private static boolean mergeStillRunning(Outcome outcome)
-    {
-        String status = outcome.mergeStatus;
-        return status != null
-            && !status.equals(ComparisonProcessStatus.MERGE_PROCESS_FINISHED.name())
-            && !status.equals(ComparisonProcessStatus.MERGE_PROCESS_DISCARDED.name())
-            && !status.equals(ComparisonProcessStatus.COMPARISON_MERGE_PROCESS_CANCELLED.name());
-    }
-
     private static void awaitMergeEnd(IComparisonManager manager, ComparisonProcessHandle handle,
         Outcome outcome) throws InterruptedException
     {
@@ -3497,18 +3497,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Closes a comparison that has been read.
-     * <p>
-     * Failure to close is logged and nothing more: the answer is already complete and correct, and
-     * turning a successful comparison into a refusal because the cleanup stumbled would be the
-     * worse trade. It is logged rather than swallowed because a comparison that will not close is
-     * exactly what the caller will feel later, when the session declines to shut down.
-     * </p>
-     *
-     * @param manager the comparison service.
-     * @param handle the process to close.
-     */
-    /**
      * Closes the comparisons the registry dropped.
      * <p>
      * Called on the way out of any comparison, because that is a moment when talking to the
@@ -3530,6 +3518,18 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Closes a comparison that has been read.
+     * <p>
+     * Failure to close is logged and nothing more: the answer is already complete and correct, and
+     * turning a successful comparison into a refusal because the cleanup stumbled would be the
+     * worse trade. It is logged rather than swallowed because a comparison that will not close is
+     * exactly what the caller will feel later, when the session declines to shut down.
+     * </p>
+     *
+     * @param manager the comparison service.
+     * @param handle the process to close.
+     */
     private static void release(IComparisonManager manager, ComparisonProcessHandle handle)
     {
         try
@@ -3815,19 +3815,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Counts the tree without changing anything in it.
-     *
-     * @param node the node to count and descend from.
-     * @param outcome the answer being built.
-     */
-    /**
-     * Names one changed object and says on which side it stands.
-     *
-     * @param node the top node, which is a metadata object.
-     * @param oneSided whether it exists on one side only.
-     * @return the description
-     */
-    /**
      * Records a piece of a module when it is one that moved.
      * <p>
      * Three ways a piece can have moved, and the narrow one is not enough: it can exist on one side
@@ -3935,6 +3922,15 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Names one changed object and says on which side it stands.
+     *
+     * @param node the top node, which is a metadata object.
+     * @param oneSided whether it exists on one side only.
+     * @param threeWay whether an ancestor is in the comparison, which decides how attribution
+     *        is read.
+     * @return the description
+     */
     private static Change describeChange(TopComparisonNode node, boolean oneSided,
         boolean threeWay)
     {
@@ -4031,17 +4027,6 @@ public final class BmComparisonHelper
     }
 
     /**
-     * Copies the environment own merge recommendation onto a change.
-     * <p>
-     * The environment already worked out which rule suits each node. Recomputing that here would be
-     * inventing a second opinion; carrying it out means a caller can confirm or override a proposal
-     * instead of deciding from nothing.
-     * </p>
-     *
-     * @param node the node.
-     * @param change where to write the recommendation.
-     */
-    /**
      * Says whether the copy that survived a one-sided deletion was changed before it was deleted.
      * <p>
      * The question a deletion cannot answer by itself. An object the delivery removed matters
@@ -4079,6 +4064,17 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Copies the environment own merge recommendation onto a change.
+     * <p>
+     * The environment already worked out which rule suits each node. Recomputing that here would be
+     * inventing a second opinion; carrying it out means a caller can confirm or override a proposal
+     * instead of deciding from nothing.
+     * </p>
+     *
+     * @param node the node.
+     * @param change where to write the recommendation.
+     */
     private static void readRecommendation(ComparisonNode node, Change change)
     {
         try
@@ -4126,6 +4122,14 @@ public final class BmComparisonHelper
         }
     }
 
+    /**
+     * Counts the tree without changing anything in it.
+     *
+     * @param node the node to count and descend from.
+     * @param outcome the answer being built.
+     * @param page which changed objects are to be named, and which page of them.
+     * @param insideModule the module this node sits in, or <code>null</code> at the top.
+     */
     private static void walk(ComparisonNode node, Outcome outcome, Page page,
         String insideModule)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmDcsHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmDcsHelper.java
@@ -1484,11 +1484,6 @@ public final class BmDcsHelper
     }
 
     /**
-     * Returns a singular factory method name for a DCS schema element class,
-     * e.g. {@code "createDataSetQuery"}. Resolves it on the cached
-     * {@link #getFactory()} instance through reflection.
-     */
-    /**
      * The area-template factory instance, or <code>null</code> when this runtime has no such model.
      *
      * @return the factory
@@ -1514,6 +1509,11 @@ public final class BmDcsHelper
         }
     }
 
+    /**
+     * Returns a singular factory method name for a DCS schema element class,
+     * e.g. {@code "createDataSetQuery"}. Resolves it on the cached
+     * {@link #getFactory()} instance through reflection.
+     */
     public static Object createElement(String factoryMethodName)
     {
         // Schema-level elements live on the schema factory, settings-level on the

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
@@ -934,30 +934,6 @@ public final class BmExtensionHelper
     }
 
     /**
-     * Resolves an EObject by FQN inside the base project's configuration.
-     * <p>
-     * Supported FQN forms:
-     * <ul>
-     *   <li>Top-level: {@code "Catalog.Users"}, {@code "Document.Order"} -
-     *       resolved via {@link MetadataTypeCatalog#findObject}.</li>
-     *   <li>Form: {@code "Catalog.Users.Form.UserForm"} - resolves the Form
-     *       metadata object (.mdo container; the BaseForm root has FQN
-     *       {@code "...Form.UserForm.Form"} which is also accepted).</li>
-     *   <li>Child element: {@code "Catalog.Users.Attribute.Email"},
-     *       {@code "Document.Order.TabularSection.Items"},
-     *       {@code "InformationRegister.Rates.Resource.Rate"},
-     *       {@code "Catalog.Users.Template.PrintForm"},
-     *       {@code "Catalog.Users.Command.Open"}.</li>
-     * </ul>
-     * <p>
-     * Strategy: first try {@code IBmTransaction.getTopObjectByFqn(fqn)} on the
-     * base project's BM model (forms / templates / many child types are
-     * registered as BM top objects in EDT 2026.1). If that returns null,
-     * fall back to splitting the FQN, finding the parent MdObject via
-     * {@link MetadataTypeCatalog}, and walking child collections by reflection
-     * ({@code getForms()}, {@code getAttributes()}, ...).
-     */
-    /**
      * Whether the model of a project holds the object a FQN names.
      * <p>
      * The one answer in this codebase to "does this address exist", and it is not
@@ -992,6 +968,30 @@ public final class BmExtensionHelper
         }
     }
 
+    /**
+     * Resolves an EObject by FQN inside the base project's configuration.
+     * <p>
+     * Supported FQN forms:
+     * <ul>
+     *   <li>Top-level: {@code "Catalog.Users"}, {@code "Document.Order"} -
+     *       resolved via {@link MetadataTypeCatalog#findObject}.</li>
+     *   <li>Form: {@code "Catalog.Users.Form.UserForm"} - resolves the Form
+     *       metadata object (.mdo container; the BaseForm root has FQN
+     *       {@code "...Form.UserForm.Form"} which is also accepted).</li>
+     *   <li>Child element: {@code "Catalog.Users.Attribute.Email"},
+     *       {@code "Document.Order.TabularSection.Items"},
+     *       {@code "InformationRegister.Rates.Resource.Rate"},
+     *       {@code "Catalog.Users.Template.PrintForm"},
+     *       {@code "Catalog.Users.Command.Open"}.</li>
+     * </ul>
+     * <p>
+     * Strategy: first try {@code IBmTransaction.getTopObjectByFqn(fqn)} on the
+     * base project's BM model (forms / templates / many child types are
+     * registered as BM top objects in EDT 2026.1). If that returns null,
+     * fall back to splitting the FQN, finding the parent MdObject via
+     * {@link MetadataTypeCatalog}, and walking child collections by reflection
+     * ({@code getForms()}, {@code getAttributes()}, ...).
+     */
     private static EObject resolveSourceEObject(IProject baseProject, String fqn)
     {
         if (fqn == null || fqn.isEmpty())
@@ -1291,18 +1291,6 @@ public final class BmExtensionHelper
     }
 
     /**
-     * Resolves the {@code IExtensionProject} for an {@link IProject}. EDT 2026.1
-     * exposes IExtensionProject as an {@link IV8Project} subtype, looked up
-     * through {@code IV8ProjectManager.getProject(IDtProject)} - the same
-     * sequence used by {@code ConfigurationInfoReader} (line 148-162).
-     * <p>
-     * 1.43.1: previous attempts went through {@code IDtProjectManager.getDtProject()}
-     * and probed {@code IDtProject.getAdapter(IExtensionProject)}, which always
-     * returned null on EDT 2026.1 because {@code IDtProject} is not an
-     * {@code IAdaptable} target for {@code IExtensionProject}. The right
-     * accessor lives on {@code IV8ProjectManager}.
-     */
-    /**
      * Auto-resolves the base configuration project of an extension by calling
      * {@code IExtensionProject.getParentProject()} (declared on IDependentProject)
      * reflectively on the already-resolved extension-project object. Returns null when
@@ -1329,6 +1317,18 @@ public final class BmExtensionHelper
         return null;
     }
 
+    /**
+     * Resolves the {@code IExtensionProject} for an {@link IProject}. EDT 2026.1
+     * exposes IExtensionProject as an {@link IV8Project} subtype, looked up
+     * through {@code IV8ProjectManager.getProject(IDtProject)} - the same
+     * sequence used by {@code ConfigurationInfoReader} (line 148-162).
+     * <p>
+     * 1.43.1: previous attempts went through {@code IDtProjectManager.getDtProject()}
+     * and probed {@code IDtProject.getAdapter(IExtensionProject)}, which always
+     * returned null on EDT 2026.1 because {@code IDtProject} is not an
+     * {@code IAdaptable} target for {@code IExtensionProject}. The right
+     * accessor lives on {@code IV8ProjectManager}.
+     */
     private static Object resolveExtensionProject(IProject project)
     {
         try

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmFormHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmFormHelper.java
@@ -913,14 +913,17 @@ public class BmFormHelper
     }
 
     /**
-     * Creates a decoration element with the specified properties.
+     * {@link #enumConstantNamed} for the test that pins the two spellings apart.
      *
-     * @param name decoration name
-     * @param title decoration title
-     * @param decorationType decoration type ("Label" or "Picture")
-     * @return the created decoration object
-     * @throws Exception if creation fails
+     * @param enumClass the EMF enum class
+     * @param wanted the constant, in either spelling
+     * @return the constant, or <code>null</code>
      */
+    static Object enumConstantNamedForTest(Class<?> enumClass, String wanted)
+    {
+        return enumConstantNamed(enumClass, wanted);
+    }
+
     /**
      * The constant of an EMF enum named either the Java way or the way the platform spells it.
      * <p>
@@ -937,18 +940,6 @@ public class BmFormHelper
      * @param wanted the constant, in either spelling; case is ignored
      * @return the constant, or <code>null</code> when the enum has none by that name
      */
-    /**
-     * {@link #enumConstantNamed} for the test that pins the two spellings apart.
-     *
-     * @param enumClass the EMF enum class
-     * @param wanted the constant, in either spelling
-     * @return the constant, or <code>null</code>
-     */
-    static Object enumConstantNamedForTest(Class<?> enumClass, String wanted)
-    {
-        return enumConstantNamed(enumClass, wanted);
-    }
-
     private static Object enumConstantNamed(Class<?> enumClass, String wanted)
     {
         Object[] constants = enumClass.getEnumConstants();
@@ -967,6 +958,15 @@ public class BmFormHelper
         return null;
     }
 
+    /**
+     * Creates a decoration element with the specified properties.
+     *
+     * @param name decoration name
+     * @param title decoration title
+     * @param decorationType decoration type ("Label" or "Picture")
+     * @return the created decoration object
+     * @throws Exception if creation fails
+     */
     public Object createDecoration(String name, String title, String decorationType) throws Exception
     {
         return createDecoration(name, title, decorationType, null);
@@ -2308,12 +2308,6 @@ public class BmFormHelper
     }
 
     /**
-     * 1.43.x: reflectively sets a single-arg scalar property (boolean / int / enum /
-     * String) on a form item by setter name, coercing the string value to the
-     * setter's parameter type via {@link #coerceFormValue}. Returns {@code null} on
-     * success, an error description otherwise (setter absent / coercion failed).
-     */
-    /**
      * Whether the value written by the last {@link #setScalarProperty} equals the model default.
      * <p>
      * EDT does not serialize a feature whose value is the default, so such a write leaves no trace
@@ -2350,6 +2344,12 @@ public class BmFormHelper
         return BmObjectHelper.equalsModelDefault(target, property);
     }
 
+    /**
+     * 1.43.x: reflectively sets a single-arg scalar property (boolean / int / enum /
+     * String) on a form item by setter name, coercing the string value to the
+     * setter's parameter type via {@link #coerceFormValue}. Returns {@code null} on
+     * success, an error description otherwise (setter absent / coercion failed).
+     */
     String setScalarProperty(Object item, String property, String value)
     {
         String setter = "set" + Character.toUpperCase(property.charAt(0)) //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmInfobaseExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmInfobaseExtensionHelper.java
@@ -310,19 +310,6 @@ public final class BmInfobaseExtensionHelper
     }
 
     /**
-     * Runs a Designer step under the handshake, without letting any step hide another.
-     * <p>
-     * The release goes first; when it throws, nothing else runs. When it released, the reconnection
-     * runs whatever the work did, and its failure is reported beside the work's rather than in
-     * place of it. When the infobase was not connected, nothing is reconnected.
-     * </p>
-     *
-     * @param release the release step
-     * @param work the Designer run
-     * @param reconnect the reconnection step
-     * @return what each step reported
-     */
-    /**
      * Runs the thick-client conversion under the per-infobase lock, and only that call under it.
      * <p>
      * Measured on a stand: holding {@code getLock(infobase)} across {@code connectInfobase} /
@@ -421,6 +408,19 @@ public final class BmInfobaseExtensionHelper
         }
     }
 
+    /**
+     * Runs a Designer step under the handshake, without letting any step hide another.
+     * <p>
+     * The release goes first; when it throws, nothing else runs. When it released, the reconnection
+     * runs whatever the work did, and its failure is reported beside the work's rather than in
+     * place of it. When the infobase was not connected, nothing is reconnected.
+     * </p>
+     *
+     * @param release the release step
+     * @param work the Designer run
+     * @param reconnect the reconnection step
+     * @return what each step reported
+     */
     public static HandshakeOutcome runUnderHandshake(Release release, Work work, Reconnect reconnect)
     {
         HandshakeOutcome outcome = new HandshakeOutcome();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmObjectHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmObjectHelper.java
@@ -62,28 +62,6 @@ public final class BmObjectHelper
     }
 
     /**
-     * Result of a metadata-mutation operation.
-     * <p>
-     * {@link #tags} carries machine-readable structured fields (e.g.
-     * {@code supportLock}, {@code standardAttributeConflict},
-     * {@code alreadyExists}, {@code notFound}) surfaced into the JSON
-     * response so AI agents can branch on them without parsing the
-     * {@link #error} text.
-     */
-    /**
-     * Why a property could not be set from text.
-     * <p>
-     * Colour, font and border are composite values in the model, not scalars: the setter takes a
-     * built object, and text cannot become one here. Until they are supported, the answer names
-     * the property and the shape it wants rather than passing out the reflection failure, which
-     * said only "argument type mismatch" and sent the caller looking for a defect.
-     * </p>
-     *
-     * @param propertyName the property that was being set, never <code>null</code>
-     * @param paramType the type its setter takes, never <code>null</code>
-     * @return the refusal text, never <code>null</code>
-     */
-    /**
      * Whether a written value is the one the model already had as its default.
      * <p>
      * A value equal to the default is not serialized, so the property reaches the object and the
@@ -120,6 +98,19 @@ public final class BmObjectHelper
         }
     }
 
+    /**
+     * Why a property could not be set from text.
+     * <p>
+     * Colour, font and border are composite values in the model, not scalars: the setter takes a
+     * built object, and text cannot become one here. Until they are supported, the answer names
+     * the property and the shape it wants rather than passing out the reflection failure, which
+     * said only "argument type mismatch" and sent the caller looking for a defect.
+     * </p>
+     *
+     * @param propertyName the property that was being set, never <code>null</code>
+     * @param paramType the type its setter takes, never <code>null</code>
+     * @return the refusal text, never <code>null</code>
+     */
     static String compositeRefusal(String propertyName, Class<?> paramType)
     {
         String wanted = paramType.getSimpleName();
@@ -129,6 +120,15 @@ public final class BmObjectHelper
             + "this operation. Nothing was changed."; //$NON-NLS-1$
     }
 
+    /**
+     * Result of a metadata-mutation operation.
+     * <p>
+     * {@link #tags} carries machine-readable structured fields (e.g.
+     * {@code supportLock}, {@code standardAttributeConflict},
+     * {@code alreadyExists}, {@code notFound}) surfaced into the JSON
+     * response so AI agents can branch on them without parsing the
+     * {@link #error} text.
+     */
     public static final class Result
     {
         public boolean ok;

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmSupportRegistryHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmSupportRegistryHelper.java
@@ -1275,21 +1275,6 @@ public final class BmSupportRegistryHelper
     }
 
     /**
-     * Builds a lookup from object identity to fully qualified name.
-     * <p>
-     * The support file records identities and no names, so this is what turns a listing into
-     * something a person can act on. Subordinate entities - attributes, forms, templates - carry
-     * their own support records and outnumber the objects several times over; they are not indexed
-     * here, and the entries that answer to them come back named as identities and counted under
-     * {@code unnamed}. That is deliberate: walking every object's contents to name them would load
-     * the whole model for a listing, and an identity reported as an identity is honest, whereas an
-     * entry silently dropped would make the listing disagree with the support file's own count.
-     * </p>
-     *
-     * @param configuration the configuration to index.
-     * @return identity to name, including the configuration root
-     */
-    /**
      * Puts one entry that has no name into the category it belongs to.
      * <p>
      * <b>Which of the two it is turns entirely on whether the walk was whole.</b> Absent from a
@@ -1442,14 +1427,6 @@ public final class BmSupportRegistryHelper
         }
     }
 
-    /**
-     * Builds the name of a subordinate as the path from its owner.
-     *
-     * @param subordinate the entity to name.
-     * @param owner the top-level object it lives under.
-     * @param ownerFqn how that object is named.
-     * @return the full path, owner first
-     */
     /**
      * Walks down from one object, naming what it finds as it goes.
      * <p>
@@ -1748,12 +1725,6 @@ public final class BmSupportRegistryHelper
     }
 
     /**
-     * Names a metadata object for the answer.
-     *
-     * @param object the object.
-     * @return its name, or <code>null</code> when it will not name itself
-     */
-    /**
      * A stable stand-in for a dependent that has no name.
      * <p>
      * Built from the object's own identity rather than from its position in the walk: a positional
@@ -1786,6 +1757,12 @@ public final class BmSupportRegistryHelper
         return type + " without a name, " + identity; //$NON-NLS-1$
     }
 
+    /**
+     * Names a metadata object for the answer.
+     *
+     * @param object the object.
+     * @return its name, or <code>null</code> when it will not name itself
+     */
     private static String nameOf(MdObject object)
     {
         try

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ComparisonSessions.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ComparisonSessions.java
@@ -262,17 +262,6 @@ public final class ComparisonSessions
     }
 
     /**
-     * Drops sessions nobody has touched within the idle limit.
-     * <p>
-     * The handles are not closed here. Closing one means talking to the environment, and a
-     * registry that did that while holding its own lock would block every other caller behind an
-     * environment call. Forgotten sessions are dropped; the comparison behind them is left to the
-     * environment, which discards a comparison with its session.
-     * </p>
-     *
-     * @param now the current time in milliseconds.
-     */
-    /**
      * Runs the idle check on its own, for the sweep that does not otherwise touch the registry.
      * <p>
      * Every other caller expires as a side effect of doing something else, which is why an idle
@@ -284,6 +273,17 @@ public final class ComparisonSessions
         expire(System.currentTimeMillis());
     }
 
+    /**
+     * Drops sessions nobody has touched within the idle limit.
+     * <p>
+     * The handles are not closed here. Closing one means talking to the environment, and a
+     * registry that did that while holding its own lock would block every other caller behind an
+     * environment call. Forgotten sessions are dropped; the comparison behind them is left to the
+     * environment, which discards a comparison with its session.
+     * </p>
+     *
+     * @param now the current time in milliseconds.
+     */
     private static void expire(long now)
     {
         Iterator<Session> sessions = OPEN.values().iterator();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/MonopolyLock.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/MonopolyLock.java
@@ -454,13 +454,6 @@ public final class MonopolyLock implements AutoCloseable
     }
 
     /**
-     * Tries to claim something, and says who has it when the answer is no.
-     *
-     * @param subject what is being claimed.
-     * @param operation what is being done to it.
-     * @return the outcome, never {@code null}
-     */
-    /**
      * What a caller is told when this instance holds the lock and is not giving it back.
      * <p>
      * Kept as a constant because it is the one refusal a caller must not answer by repeating the
@@ -514,6 +507,13 @@ public final class MonopolyLock implements AutoCloseable
         return said.toString();
     }
 
+    /**
+     * Tries to claim something, and says who has it when the answer is no.
+     *
+     * @param subject what is being claimed.
+     * @param operation what is being done to it.
+     * @return the outcome, never {@code null}
+     */
     public static Claim claim(String subject, String operation)
     {
         if (subject == null || subject.isEmpty())

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/PendingWorkRegistry.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/PendingWorkRegistry.java
@@ -719,9 +719,6 @@ public final class PendingWorkRegistry
     }
 
     /**
-     * Per-runKey state for the registry.
-     */
-    /**
      * What a caller gets when the work threw instead of answering.
      * <p>
      * A structured refusal, not the sentence {@code "Error: " + message} this used to return. That
@@ -753,6 +750,9 @@ public final class PendingWorkRegistry
             .toJson();
     }
 
+    /**
+     * Per-runKey state for the registry.
+     */
     public static final class PendingEntry
     {
         public final String runKey;

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/DcsWorkshopTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/DcsWorkshopTool.java
@@ -481,16 +481,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * Generic schema-mutation dispatch that runs inside BmDcsHelper.executeWriteOnSchema.
-     * Per-op semantics are implemented inline so the BM transaction holds for one op.
-     * <p>
-     * Each op resolves the schema {@link EObject} via reflection, mutates the
-     * corresponding child collection (DataSets / Parameters / CalculatedFields /
-     * ConditionalAppearance / DefaultSettings.Structure / DefaultSettings.Filter),
-     * and records a short message in {@link BmDcsHelper.Result#message}. Errors
-     * surface as {@link MetadataGuards.BlockedGuardException} with structured tags.
-     */
-    /**
      * Whether the call is aimed at a form's dynamic list rather than at a schema in a template.
      *
      * @param formFqn the form, when one was given.
@@ -547,31 +537,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * The schema an operation is aimed at.
-     * <p>
-     * Two coordinates reach a schema in a template; a third reaches a schema nested inside it.
-     * Without that third one a nested schema could be created and never written into - and a call
-     * meant for it would have gone to the schema around it and reported success.
-     * </p>
-     *
-     * @param root the schema the FQN resolved to.
-     * @param nestedSchemaName the nested schema to work inside, or <code>null</code> for the root.
-     * @return the schema to write to
-     */
-    /**
-     * The steps of a name that may be a path down a hierarchy.
-     * <p>
-     * A name is taken whole first by the callers of this method, so this is only reached for a name
-     * that is not there as written. Every step must be a name: Java drops a trailing empty segment,
-     * so "Outer." would silently become "Outer" and act on the wrong node, and "." would become no
-     * steps at all and act on the root.
-     * </p>
-     *
-     * @param path the name as the caller wrote it.
-     * @param what the kind of thing being addressed, for the refusal.
-     * @return its steps, each non-empty
-     */
-    /**
      * The text an export has to contain for a named element to be in it.
      * <p>
      * The file is XML, so a name is escaped there. Looking for the raw name would report a write as
@@ -621,6 +586,19 @@ public class DcsWorkshopTool implements IMcpTool
         }
     }
 
+    /**
+     * The steps of a name that may be a path down a hierarchy.
+     * <p>
+     * A name is taken whole first by the callers of this method, so this is only reached for a name
+     * that is not there as written. Every step must be a name: Java drops a trailing empty segment,
+     * so "Outer." would silently become "Outer" and act on the wrong node, and "." would become no
+     * steps at all and act on the root.
+     * </p>
+     *
+     * @param path the name as the caller wrote it.
+     * @param what the kind of thing being addressed, for the refusal.
+     * @return its steps, each non-empty
+     */
     private static String[] pathSteps(String path, String what)
     {
         String[] steps = path.split("\\.", -1); //$NON-NLS-1$
@@ -654,6 +632,18 @@ public class DcsWorkshopTool implements IMcpTool
         }
     }
 
+    /**
+     * The schema an operation is aimed at.
+     * <p>
+     * Two coordinates reach a schema in a template; a third reaches a schema nested inside it.
+     * Without that third one a nested schema could be created and never written into - and a call
+     * meant for it would have gone to the schema around it and reported success.
+     * </p>
+     *
+     * @param root the schema the FQN resolved to.
+     * @param nestedSchemaName the nested schema to work inside, or <code>null</code> for the root.
+     * @return the schema to write to
+     */
     private EObject schemaToWorkIn(EObject root, String nestedSchemaName)
     {
         if (nestedSchemaName == null || nestedSchemaName.isEmpty())
@@ -694,6 +684,16 @@ public class DcsWorkshopTool implements IMcpTool
         return current;
     }
 
+    /**
+     * Generic schema-mutation dispatch that runs inside BmDcsHelper.executeWriteOnSchema.
+     * Per-op semantics are implemented inline so the BM transaction holds for one op.
+     * <p>
+     * Each op resolves the schema {@link EObject} via reflection, mutates the
+     * corresponding child collection (DataSets / Parameters / CalculatedFields /
+     * ConditionalAppearance / DefaultSettings.Structure / DefaultSettings.Filter),
+     * and records a short message in {@link BmDcsHelper.Result#message}. Errors
+     * surface as {@link MetadataGuards.BlockedGuardException} with structured tags.
+     */
     private String opSchemaMutation(String op, Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$
@@ -1317,18 +1317,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * Adds a nested schema to the schema root.
-     * <p>
-     * A nested schema is a composition schema of its own, named and addressed from the outer one.
-     * It is created empty: what goes inside it is written by the same operations that write the
-     * outer schema, aimed at it by name.
-     * </p>
-     *
-     * @param params name, and optionally title and url.
-     * @param schema the schema root.
-     * @return the name written
-     */
-    /**
      * Writes a property and refuses when it did not take.
      * <p>
      * The setter is found by name, so a name the model spells differently reports back that the
@@ -1349,6 +1337,18 @@ public class DcsWorkshopTool implements IMcpTool
         }
     }
 
+    /**
+     * Adds a nested schema to the schema root.
+     * <p>
+     * A nested schema is a composition schema of its own, named and addressed from the outer one.
+     * It is created empty: what goes inside it is written by the same operations that write the
+     * outer schema, aimed at it by name.
+     * </p>
+     *
+     * @param params name, and optionally title and url.
+     * @param schema the schema root.
+     * @return the name written
+     */
     private Object doAddNestedSchema(Map<String, String> params, EObject schema)
     {
         String name = required(params, "name"); //$NON-NLS-1$
@@ -1406,24 +1406,6 @@ public class DcsWorkshopTool implements IMcpTool
             "nestedSchemas"); //$NON-NLS-1$
     }
 
-    /**
-     * Removes a nested schema by name.
-     *
-     * @param params the name.
-     * @param schema the schema root.
-     * @return the name removed
-     */
-    /**
-     * Adds a named template to the schema, with an empty body.
-     * <p>
-     * A schema names its templates and then says which field or grouping is drawn with each. The
-     * body is filled by add_template_row and add_template_cell.
-     * </p>
-     *
-     * @param params the name.
-     * @param schema the schema root.
-     * @return what the write guards need to see
-     */
     /**
      * An integer argument, refusing a value that is not one.
      * <p>
@@ -1577,6 +1559,17 @@ public class DcsWorkshopTool implements IMcpTool
         return null;
     }
 
+    /**
+     * Adds a named template to the schema, with an empty body.
+     * <p>
+     * A schema names its templates and then says which field or grouping is drawn with each. The
+     * body is filled by add_template_row and add_template_cell.
+     * </p>
+     *
+     * @param params the name.
+     * @param schema the schema root.
+     * @return what the write guards need to see
+     */
     private Object doAddSchemaTemplate(Map<String, String> params, EObject schema)
     {
         String name = required(params, "name"); //$NON-NLS-1$
@@ -1796,13 +1789,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * Says which named template draws a grouping, as its header or as its body.
-     *
-     * @param params groupName, schemaTemplateName, templateType and header.
-     * @param schema the schema root.
-     * @return what the write guards need to see
-     */
-    /**
      * Says which template draws the totals where two groupings cross.
      * <p>
      * The entry names both groupings and the area type of each, so all four together are what tell
@@ -1916,19 +1902,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * Whether an entry carries the area type a call asked for.
-     * <p>
-     * A call naming none means the model's default, because an entry made without one carries that
-     * rather than nothing.
-     * </p>
-     *
-     * @param entry the entry.
-     * @param feature the feature name, for reading its default.
-     * @param getter how to read what the entry carries.
-     * @param asked what the call named, or <code>null</code>.
-     * @return true when they are the same type
-     */
-    /**
      * The spelling the model uses for one of a feature's constants.
      *
      * @param feature the feature the constant belongs to.
@@ -1954,6 +1927,19 @@ public class DcsWorkshopTool implements IMcpTool
         return null;
     }
 
+    /**
+     * Whether an entry carries the area type a call asked for.
+     * <p>
+     * A call naming none means the model's default, because an entry made without one carries that
+     * rather than nothing.
+     * </p>
+     *
+     * @param entry the entry.
+     * @param feature the feature name, for reading its default.
+     * @param getter how to read what the entry carries.
+     * @param asked what the call named, or <code>null</code>.
+     * @return true when they are the same type
+     */
     private boolean sameAreaType(EObject entry, String feature, String getter, String asked)
     {
         Object heldType = invokeGetter(entry, getter);
@@ -1984,6 +1970,13 @@ public class DcsWorkshopTool implements IMcpTool
         return held != null && wanted.equalsIgnoreCase(held);
     }
 
+    /**
+     * Says which named template draws a grouping, as its header or as its body.
+     *
+     * @param params groupName, schemaTemplateName, templateType and header.
+     * @param schema the schema root.
+     * @return what the write guards need to see
+     */
     private Object doAddGroupTemplate(Map<String, String> params, EObject schema)
     {
         String groupName = required(params, "groupName"); //$NON-NLS-1$
@@ -2118,6 +2111,13 @@ public class DcsWorkshopTool implements IMcpTool
         return null;
     }
 
+    /**
+     * Removes a nested schema by name.
+     *
+     * @param params the name.
+     * @param schema the schema root.
+     * @return the name removed
+     */
     private Object doRemoveNestedSchema(Map<String, String> params, EObject schema)
     {
         String name = required(params, "name"); //$NON-NLS-1$
@@ -3430,6 +3430,11 @@ public class DcsWorkshopTool implements IMcpTool
      * Without {@code variantName} this is what every other settings operation uses - the first
      * variant, created when the schema has none. A dynamic list's settings are their own top object
      * with no variants above them, so naming one there is refused rather than ignored.
+     * </p>
+     * <p>
+     * A variant's settings rather than {@code Schema.getDefaultSettings()}: the schema editor draws
+     * settings from variants, so a schema whose settings live only in {@code defaultSettings} opens
+     * empty. That is why a variant is created when the schema carries none.
      * </p>
      *
      * @param schema the schema, or a settings container in the case of a dynamic list.
@@ -5429,17 +5434,6 @@ public class DcsWorkshopTool implements IMcpTool
     }
 
     /**
-     * Returns the DataCompositionSettings that all settings operations
-     * (grouping/filter/order/selection/appearance/...) must write into.
-     * <p>
-     * Critically, this is the settings tree of the "Основной" {@code SettingsVariant},
-     * NOT {@code Schema.getDefaultSettings()}. The report's schema editor renders
-     * settings from VARIANTS; a schema whose settings live only in defaultSettings
-     * (with no variant) opens read-only / empty - exactly what the EDT wizard avoids
-     * by always creating an "Основной" variant. Reuses the first existing variant or
-     * creates "Основной".
-     */
-    /**
      * Whether this object IS the settings, rather than something holding them.
      * <p>
      * Told apart by shape, not by class name: a settings container carries the filter, order and
@@ -5887,13 +5881,6 @@ public class DcsWorkshopTool implements IMcpTool
         return Collections.unmodifiableMap(m);
     }
 
-    /**
-     * Builds the schema-mutation registry: op name -> handler applied on the DCS
-     * schema inside the BM write transaction. Each handler is the exact call the
-     * former applySchemaMutation switch made. Alias pairs (add_chart /
-     * add_settings_chart, add_order / add_settings_order, select_field /
-     * add_settings_selected_field, ...) are separate entries sharing one handler.
-     */
     @SuppressWarnings("nls")
     /**
      * The operations this tool can run.
@@ -5933,6 +5920,13 @@ public class DcsWorkshopTool implements IMcpTool
             null);
     }
 
+    /**
+     * Builds the schema-mutation registry: op name -> handler applied on the DCS
+     * schema inside the BM write transaction. Each handler is the exact call the
+     * former applySchemaMutation switch made. Alias pairs (add_chart /
+     * add_settings_chart, add_order / add_settings_order, select_field /
+     * add_settings_selected_field, ...) are separate entries sharing one handler.
+     */
     private Map<String, MutationHandler> buildMutationRegistry()
     {
         Map<String, MutationHandler> m = new LinkedHashMap<>();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/EditMetadataTool.java
@@ -166,19 +166,6 @@ public class EditMetadataTool implements IMcpTool
     private static final int FAILURES_NAMED = 5;
 
     /**
-     * Why each failed operation failed, for the message the batch demotes itself with.
-     * <p>
-     * The message used to point at batchResults[] instead of carrying this. The array is there, in
-     * the structured payload - but the text channel gets a summary, and for a failure that summary
-     * is the failure text alone. A caller reading text was therefore sent to an array it had not
-     * been given, and the only way left was to reissue the operations one at a time, which is what
-     * a batch exists to avoid.
-     * </p>
-     *
-     * @param results one entry per operation, as put into batchResults
-     * @return the lines naming the failures; never <code>null</code>
-     */
-    /**
      * The reason one failed batch entry carries.
      * <p>
      * An operation rejected before dispatch puts it in {@code error}; one that ran and refused puts
@@ -222,6 +209,19 @@ public class EditMetadataTool implements IMcpTool
         return "failed without saying why"; //$NON-NLS-1$
     }
 
+    /**
+     * Why each failed operation failed, for the message the batch demotes itself with.
+     * <p>
+     * The message used to point at batchResults[] instead of carrying this. The array is there, in
+     * the structured payload - but the text channel gets a summary, and for a failure that summary
+     * is the failure text alone. A caller reading text was therefore sent to an array it had not
+     * been given, and the only way left was to reissue the operations one at a time, which is what
+     * a batch exists to avoid.
+     * </p>
+     *
+     * @param results one entry per operation, as put into batchResults
+     * @return the lines naming the failures; never <code>null</code>
+     */
     private static String whyEachFailed(List<Map<String, Object>> results)
     {
         StringBuilder sb = new StringBuilder();
@@ -713,6 +713,12 @@ public class EditMetadataTool implements IMcpTool
         return executeSinglePending(op, params);
     }
 
+    /** Separator between the key and the value in a call identity. */
+    private static final char EQUALS = '=';
+
+    /** Separator between one key-value pair and the next in a call identity. */
+    private static final char SEPARATOR = ';';
+
     /**
      * Runs one operation, handing back a runKey if it outlives the caller's patience.
      * <p>
@@ -727,12 +733,6 @@ public class EditMetadataTool implements IMcpTool
      * @param params the call parameters, never {@code null}
      * @return the operation result when it finishes in time, a Pending answer otherwise
      */
-    /** Separator between the key and the value in a call identity. */
-    private static final char EQUALS = '=';
-
-    /** Separator between one key-value pair and the next in a call identity. */
-    private static final char SEPARATOR = ';';
-
     private String executeSinglePending(String op, Map<String, String> params)
     {
         long softTimeoutMs = Math.max(5, Math.min(120,
@@ -1682,15 +1682,6 @@ public class EditMetadataTool implements IMcpTool
     }
 
     /**
-     * Fills the {@code synonym} (EMap&lt;lang,text&gt;) of a freshly created
-     * metadata object (attribute, EventSubscription, Catalog, ...): explicit
-     * value when supplied, otherwise auto-generated from the name like the EDT
-     * wizard. Language is the configuration default, falling back to {@code ru}.
-     * Best-effort - a setter failure (e.g. a type that has no synonym) is logged,
-     * never fatal. Returns a {@link SynonymResult} so callers can surface the
-     * outcome to the agent instead of letting it be silently lost.
-     */
-    /**
      * True when {@code mdObject} has no usable synonym (null/empty map, or every
      * localization value blank). Used on idempotent retry paths to decide whether
      * an OMITTED synonym may be auto-generated: a blank existing synonym can be
@@ -1736,6 +1727,15 @@ public class EditMetadataTool implements IMcpTool
         return ru.aiedt.mcp.server.support.DefaultLanguage.codeFor(project);
     }
 
+    /**
+     * Fills the {@code synonym} (EMap&lt;lang,text&gt;) of a freshly created
+     * metadata object (attribute, EventSubscription, Catalog, ...): explicit
+     * value when supplied, otherwise auto-generated from the name like the EDT
+     * wizard. Language is the configuration default, falling back to {@code ru}.
+     * Best-effort - a setter failure (e.g. a type that has no synonym) is logged,
+     * never fatal. Returns a {@link SynonymResult} so callers can surface the
+     * outcome to the agent instead of letting it be silently lost.
+     */
     static SynonymResult applyMdObjectSynonym(MdObject mdObject, String explicitSynonym,
         String name, IProject project)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MetadataDetailsReader.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MetadataDetailsReader.java
@@ -288,23 +288,6 @@ public class MetadataDetailsReader
     }
 
     /**
-     * Answers for the configuration root, which no collection holds.
-     * <p>
-     * Accepts {@code Configuration} on its own and {@code Configuration.<name>}, in
-     * English or Russian. A name that does not match is refused by NAME rather than
-     * silently formatting the only configuration there is - the caller who spelled it
-     * wrong is otherwise told about an object they did not ask for.
-     * </p>
-     *
-     * @param configuration the project's configuration (non-null)
-     * @param fqn the requested FQN
-     * @param full whether the caller asked for the full view
-     * @param language the requested language, or <code>null</code>
-     * @param view the requested sections
-     * @return the formatted root, an error naming the mismatch, or <code>null</code> when
-     *         {@code fqn} does not address the root at all
-     */
-    /**
      * Reads an FQN as a request for the configuration root.
      *
      * @param fqn the requested FQN (nullable)
@@ -327,6 +310,23 @@ public class MetadataDetailsReader
         return dot < 0 ? "" : trimmed.substring(dot + 1).trim(); //$NON-NLS-1$
     }
 
+    /**
+     * Answers for the configuration root, which no collection holds.
+     * <p>
+     * Accepts {@code Configuration} on its own and {@code Configuration.<name>}, in
+     * English or Russian. A name that does not match is refused by NAME rather than
+     * silently formatting the only configuration there is - the caller who spelled it
+     * wrong is otherwise told about an object they did not ask for.
+     * </p>
+     *
+     * @param configuration the project's configuration (non-null)
+     * @param fqn the requested FQN
+     * @param full whether the caller asked for the full view
+     * @param language the requested language, or <code>null</code>
+     * @param view the requested sections
+     * @return the formatted root, an error naming the mismatch, or <code>null</code> when
+     *         {@code fqn} does not address the root at all
+     */
     private static String configurationRootDetails(Configuration configuration, String fqn,
         boolean full, String language, View view)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MetadataObjectsReader.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MetadataObjectsReader.java
@@ -545,10 +545,6 @@ public class MetadataObjectsReader
     }
 
     /**
-     * @param typeLower the lowercased type token
-     * @return the matching collector, or <code>null</code>
-     */
-    /**
      * The collector for a kind, whether or not the category array names it.
      * <p>
      * A kind with no entry still gets walked - it just reports no object or manager module, which
@@ -581,6 +577,10 @@ public class MetadataObjectsReader
         return findCollector(typeLower);
     }
 
+    /**
+     * @param typeLower the lowercased type token
+     * @return the matching collector, or <code>null</code>
+     */
     private static Collector findCollector(String typeLower)
     {
         for (Collector collector : COLLECTORS)

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MiscOps.java
@@ -53,7 +53,6 @@ final class MiscOps
         return null;
     }
 
-    /** Adds {@code item} to a raw {@link EList} (unchecked, EMF validates element type). */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     /**
      * J2b (Functional Options on form items): adds or removes a FunctionalOption
@@ -192,13 +191,6 @@ final class MiscOps
         return ok.toJson();
     }
 
-    /**
-     * Finds the first single-argument setter method named {@code setterName} on
-     * {@code clazz}, scanning public methods (EMF reference setters take the
-     * referenced interface type, which the caller does not know ahead of time,
-     * so {@code getMethod(name, exactType)} is not usable). Returns {@code null}
-     * when no such method exists.
-     */
     // -----------------------------------------------------------------------
     // Common operations (1.37)
     // -----------------------------------------------------------------------
@@ -371,12 +363,6 @@ final class MiscOps
     // -----------------------------------------------------------------------
 
     /**
-     * 1.40: dispatcher for the 5 Extensions ops (adoptObject, adoptObjects,
-     * adoptChild, adoptFormItem, adoptModule). Probes the underlying adopt
-     * service via {@link BmExtensionHelper}; surfaces a graceful
-     * {@code adoptServiceNotFound} tag when the API is missing.
-     */
-    /**
      * Builds the FQN of a child when the caller named its owner, its kind and its name.
      * <p>
      * <b>Measured on a stand, and it borrowed the wrong thing.</b> The schema has said since 1.43
@@ -425,6 +411,12 @@ final class MiscOps
         return fqn + "." + kind.trim() + "." + name.trim(); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
+    /**
+     * 1.40: dispatcher for the 5 Extensions ops (adoptObject, adoptObjects,
+     * adoptChild, adoptFormItem, adoptModule). Probes the underlying adopt
+     * service via {@link BmExtensionHelper}; surfaces a graceful
+     * {@code adoptServiceNotFound} tag when the API is missing.
+     */
     String opExtensionAdopt(String op, Map<String, String> params)
     {
         if (!BmExtensionHelper.isAvailable())
@@ -700,9 +692,4 @@ final class MiscOps
         return m;
     }
 
-    /**
-     * Wraps a {@link BmFormHelper#executeFormOperation} return value into our
-     * standard JSON response shape. The helper returns {@code null} on
-     * success, or an "Error: ..." string otherwise.
-     */
 }

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MxlWorkshopTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/MxlWorkshopTool.java
@@ -326,9 +326,6 @@ public class MxlWorkshopTool implements IMcpTool
     }
 
     /**
-     * 1.42.2: native cell merge via the moxel SpreadsheetDocument model.
-     */
-    /**
      * Names an area of a template.
      * <p>
      * The mechanism that loads data from a file reads a template by its named areas: an area name
@@ -512,6 +509,9 @@ public class MxlWorkshopTool implements IMcpTool
             .toJson();
     }
 
+    /**
+     * 1.42.2: native cell merge via the moxel SpreadsheetDocument model.
+     */
     private String opMergeCells(Map<String, String> params)
     {
         if (!BmTemplateHelper.cellOpsAvailable())
@@ -1042,10 +1042,6 @@ public class MxlWorkshopTool implements IMcpTool
     }
 
     /**
-     * Locates the named Template MdObject inside the owner. Throws when the
-     * owner has no Templates collection or the named template is missing.
-     */
-    /**
      * Turns a write that never reached the file into a failure.
      * <p>
      * The mutation lands in the in-memory moxel model first and is then written to
@@ -1074,6 +1070,10 @@ public class MxlWorkshopTool implements IMcpTool
         }
     }
 
+    /**
+     * Locates the named Template MdObject inside the owner. Throws when the
+     * owner has no Templates collection or the named template is missing.
+     */
     private static MdObject resolveTemplate(MdObject owner, String templateName)
     {
         @SuppressWarnings("unchecked")

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ProjectProblemsReader.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ProjectProblemsReader.java
@@ -203,21 +203,6 @@ public class ProjectProblemsReader
     }
 
     /**
-     * Counts the errors standing against a named set of objects.
-     * <p>
-     * Exists so that "how many errors are on these objects" has ONE answer in this codebase. The
-     * caller is a merge, which leaves a configuration in a state nobody has looked at yet and must
-     * not report success without saying whether the project still validates - but a second counter
-     * written next to the merge would drift from this one, and two answers to one question is worse
-     * than a slightly wider public surface here.
-     * </p>
-     *
-     * @param projectName the project the objects belong to; may be <code>null</code> for all.
-     * @param objects the object FQNs to count against; empty counts nothing.
-     * @return the number of ERROR-severity markers, or -1 when the marker service is unavailable
-     *         and the question therefore has no answer rather than the answer zero
-     */
-    /**
      * Counts every error standing against a project, not only against named objects.
      * <p>
      * The baseline an irreversible operation is judged against. Counting only the objects that
@@ -245,6 +230,21 @@ public class ProjectProblemsReader
             .value;
     }
 
+    /**
+     * Counts the errors standing against a named set of objects.
+     * <p>
+     * Exists so that "how many errors are on these objects" has ONE answer in this codebase. The
+     * caller is a merge, which leaves a configuration in a state nobody has looked at yet and must
+     * not report success without saying whether the project still validates - but a second counter
+     * written next to the merge would drift from this one, and two answers to one question is worse
+     * than a slightly wider public surface here.
+     * </p>
+     *
+     * @param projectName the project the objects belong to; may be <code>null</code> for all.
+     * @param objects the object FQNs to count against; empty counts nothing.
+     * @return the number of ERROR-severity markers, or -1 when the marker service is unavailable
+     *         and the question therefore has no answer rather than the answer zero
+     */
     public static long countErrorsOn(String projectName, List<String> objects)
     {
         if (objects == null || objects.isEmpty())
@@ -485,23 +485,6 @@ public class ProjectProblemsReader
     }
 
     /**
-     * The answer for a query that matched nothing, naming every filter that was in
-     * force when it matched nothing.
-     * <p>
-     * Every filter, including the ones the caller did not set. An empty answer is a
-     * claim about the project, and it is only true within the filters that produced it;
-     * omitting one turns "nothing at this severity" into "nothing", which is how a check
-     * with live findings came to be recorded as a check that does not fire.
-     * </p>
-     *
-     * @param resolvedScope the scope actually used.
-     * @param projectName the project filter, or <code>null</code>/empty for none.
-     * @param severity the severity argument as given, <code>null</code> for the default.
-     * @param checkId the check filter, or <code>null</code>/empty for none.
-     * @param objects the object filter; never <code>null</code>.
-     * @return the markdown.
-     */
-    /**
      * The heading that names the requested addresses the model does not hold.
      * <p>
      * Asked through {@link BmExtensionHelper#addressResolves}, which is the same question
@@ -579,6 +562,23 @@ public class ProjectProblemsReader
     // reached this with the filters stripped, and told a caller who had asked for ALL
     // that the default was in force. A test is what keeps the two paths saying the same
     // thing.
+    /**
+     * The answer for a query that matched nothing, naming every filter that was in
+     * force when it matched nothing.
+     * <p>
+     * Every filter, including the ones the caller did not set. An empty answer is a
+     * claim about the project, and it is only true within the filters that produced it;
+     * omitting one turns "nothing at this severity" into "nothing", which is how a check
+     * with live findings came to be recorded as a check that does not fire.
+     * </p>
+     *
+     * @param resolvedScope the scope actually used.
+     * @param projectName the project filter, or <code>null</code>/empty for none.
+     * @param severity the severity argument as given, <code>null</code> for the default.
+     * @param checkId the check filter, or <code>null</code>/empty for none.
+     * @param objects the object filter; never <code>null</code>.
+     * @return the markdown.
+     */
     static String nothingFoundMessage(String resolvedScope, String projectName, String severity,
         String checkId, List<String> objects)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SpecializedOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SpecializedOps.java
@@ -222,14 +222,6 @@ final class SpecializedOps
         return EditMetadataTool.formatResult(r, "remove_command"); //$NON-NLS-1$
     }
 
-    /**
-     * 1.42 helper: returns the {@code getCommands()} EList of an MdObject via
-     * reflection. Returns {@code null} only when the type has no
-     * {@code getCommands()} method at all (e.g. Constant, CommonModule,
-     * Subsystem). When the method exists but throws at runtime the helper
-     * rethrows so the failure surfaces as an action error - hiding it would
-     * make the caller report a misleading "this type has no commands".
-     */
 
     /**
      * 1.42 (RSV 4.2 parity): blocks until every pending BM export for the
@@ -338,6 +330,14 @@ final class SpecializedOps
         return out.toJson();
     }
 
+    /**
+     * 1.42 helper: returns the {@code getCommands()} EList of an MdObject via
+     * reflection. Returns {@code null} only when the type has no
+     * {@code getCommands()} method at all (e.g. Constant, CommonModule,
+     * Subsystem). When the method exists but throws at runtime the helper
+     * rethrows so the failure surfaces as an action error - hiding it would
+     * make the caller report a misleading "this type has no commands".
+     */
     private static EList<MdObject> getCommandsCollection(MdObject owner)
     {
         try

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/SyncControlTool.java
@@ -957,11 +957,6 @@ public class SyncControlTool implements IMcpTool
     // reseed_baseline / mark_synchronized already use.
 
     /**
-     * Read-only: reports every infobase lock holder EDT has created THIS session and whether its
-     * flow-active flag is stuck (project != null). Only infobases touched this session appear -
-     * inherent to an in-memory-only map.
-     */
-    /**
      * Lists the support-mode snapshots a project holds, saying which cleanup will not touch.
      * <p>
      * The names matter, not the count. A protected snapshot is released one at a time, by the file
@@ -1083,6 +1078,11 @@ public class SyncControlTool implements IMcpTool
         return project.getLocation().toFile().toPath().resolve(".settings"); //$NON-NLS-1$
     }
 
+    /**
+     * Read-only: reports every infobase lock holder EDT has created THIS session and whether its
+     * flow-active flag is stuck (project != null). Only infobases touched this session appear -
+     * inherent to an in-memory-only map.
+     */
     private String doDiagnoseStuckLocks(IProject project)
     {
         try

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/TemplateOps.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/TemplateOps.java
@@ -30,14 +30,6 @@ import ru.aiedt.mcp.server.support.ProjectResolver;
 final class TemplateOps
 {
     /**
-     * add_template - creates a Template (mdclass Template) under an owner metadata object. Fills
-     * SpreadsheetDocument .mxlx and TextDocument/HTMLDocument content files post-commit so the
-     * template is usable right away. Honors dryRun.
-     *
-     * @param params the tool parameters
-     * @return the JSON result document
-     */
-    /**
      * Why a data composition schema is not made here.
      * <p>
      * This operation creates the template object and nothing inside it. For every other type that
@@ -62,6 +54,14 @@ final class TemplateOps
             + "template and the schema together."; //$NON-NLS-1$
     }
 
+    /**
+     * add_template - creates a Template (mdclass Template) under an owner metadata object. Fills
+     * SpreadsheetDocument .mxlx and TextDocument/HTMLDocument content files post-commit so the
+     * template is usable right away. Honors dryRun.
+     *
+     * @param params the tool parameters
+     * @return the JSON result document
+     */
     String opAddTemplate(Map<String, String> params)
     {
         String projectName = JsonUtils.extractStringArgument(params, "projectName"); //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ThreeWayComparisonTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ThreeWayComparisonTool.java
@@ -268,18 +268,6 @@ public class ThreeWayComparisonTool
     }
 
     /**
-     * Reads the decisions a caller passed.
-     * <p>
-     * Malformed input is refused with a reason rather than silently treated as no decisions: a
-     * caller who wrote decisions and got a comparison back without them would believe they had been
-     * recorded.
-     * </p>
-     *
-     * @param json the argument as written; may be <code>null</code>.
-     * @return the decisions, empty when none were given
-     * @throws IllegalArgumentException when the argument is there but unreadable
-     */
-    /**
      * Reads the objects a caller wants compared, when they want less than everything.
      *
      * @param params the call.
@@ -303,6 +291,18 @@ public class ThreeWayComparisonTool
         return names;
     }
 
+    /**
+     * Reads the decisions a caller passed.
+     * <p>
+     * Malformed input is refused with a reason rather than silently treated as no decisions: a
+     * caller who wrote decisions and got a comparison back without them would believe they had been
+     * recorded.
+     * </p>
+     *
+     * @param json the argument as written; may be <code>null</code>.
+     * @return the decisions, empty when none were given
+     * @throws IllegalArgumentException when the argument is there but unreadable
+     */
     private static List<BmComparisonHelper.Decision> readDecisions(String json)
     {
         List<BmComparisonHelper.Decision> decisions = new ArrayList<>();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/VanessaTool.java
@@ -1144,11 +1144,6 @@ public class VanessaTool implements IMcpTool
     }
 
     /**
-     * {@code 1cv8 ENTERPRISE /IBConnectionString "<conn>" /DisableStartupMessages
-     * /Execute <epf> /C "StartFeaturePlayer;VAParams=<params>"} (thick client;
-     * {@code /DisableStartupMessages} avoids the "update configuration?" modal).
-     */
-    /**
      * The parameters this tool sets because it reads the result back from where they point.
      * <p>
      * Moving the report or the screenshot directory would leave the run reading an empty file and
@@ -1384,6 +1379,11 @@ public class VanessaTool implements IMcpTool
         }
     }
 
+    /**
+     * {@code 1cv8 ENTERPRISE /IBConnectionString "<conn>" /DisableStartupMessages
+     * /Execute <epf> /C "StartFeaturePlayer;VAParams=<params>"} (thick client;
+     * {@code /DisableStartupMessages} avoids the "update configuration?" modal).
+     */
     private static List<String> buildCommand(File exe, String connectionString, File epf,
         File paramsFile, boolean asTestManager)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/McpRequestRouter.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/McpRequestRouter.java
@@ -1054,16 +1054,6 @@ public class McpRequestRouter
     }
 
     /**
-     * Shapes a tool's answer according to the kind of content it produces.
-     *
-     * @param tool the tool that ran
-     * @param arguments the arguments it ran with, needed to name the resource it produced
-     * @param rawResult what it produced
-     * @param signal a user signal picked up while it ran, or <code>null</code>
-     * @param plainTextMode whether rich shapes must degrade to text
-     * @return the tools/call result
-     */
-    /**
      * Marks an answer as a reported failure, leaving it alone otherwise.
      *
      * @param result the answer.
@@ -1075,6 +1065,16 @@ public class McpRequestRouter
         return failed && result != null ? result.asFailure() : result;
     }
 
+    /**
+     * Shapes a tool's answer according to the kind of content it produces.
+     *
+     * @param tool the tool that ran
+     * @param arguments the arguments it ran with, needed to name the resource it produced
+     * @param rawResult what it produced
+     * @param signal a user signal picked up while it ran, or <code>null</code>
+     * @param plainTextMode whether rich shapes must degrade to text
+     * @return the tools/call result
+     */
     static ToolCallResult shapeResult(IMcpTool tool, Map<String, String> arguments,
         String rawResult, OperatorSignal signal, boolean plainTextMode)
     {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/DiscoverResult.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/DiscoverResult.java
@@ -134,10 +134,6 @@ public class DiscoverResult
         return cacheScope;
     }
 
-    /**
-     * What this server can do. Tools, and nothing else - the same answer the handshake gives, so
-     * the two eras cannot describe the server differently.
-     */
     /** Who answered. */
     public static class ServerInfo
     {
@@ -172,6 +168,10 @@ public class DiscoverResult
         }
     }
 
+    /**
+     * What this server can do. Tools, and nothing else - the same answer the handshake gives, so
+     * the two eras cannot describe the server differently.
+     */
     public static class Capabilities
     {
         private final Tools tools = new Tools();

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/JsonRpcError.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/JsonRpcError.java
@@ -43,11 +43,6 @@ public class JsonRpcError
     }
 
     /**
-     * Returns the error code.
-     *
-     * @return the code
-     */
-    /**
      * Attaches what the caller needs to act on this error.
      *
      * @param data the payload; null leaves the member off the wire.
@@ -69,6 +64,11 @@ public class JsonRpcError
         return data;
     }
 
+    /**
+     * Returns the error code.
+     *
+     * @return the code
+     */
     public int getCode()
     {
         return code;

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/ToolCallResult.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/wire/jsonrpc/ToolCallResult.java
@@ -126,11 +126,6 @@ public class ToolCallResult
     }
 
     /**
-     * Returns the structured payload.
-     *
-     * @return the payload, or <code>null</code> when the result is not structured
-     */
-    /**
      * Marks this answer as a failure the tool reported rather than threw.
      *
      * @return this result, for chaining.
@@ -151,6 +146,11 @@ public class ToolCallResult
         return isError;
     }
 
+    /**
+     * Returns the structured payload.
+     *
+     * @return the payload, or <code>null</code> when the result is not structured
+     */
     public Object getStructuredContent()
     {
         return structuredContent;

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/workbench/McpStatusBarItem.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/workbench/McpStatusBarItem.java
@@ -898,13 +898,6 @@ public class McpStatusBarItem
     }
 
     /**
-     * Opens the signal dialog and delivers whatever the user sends. Does nothing unless a tool is
-     * actually executing.
-     *
-     * @param type  the kind of signal
-     * @param title the dialog title
-     */
-    /**
      * Shows the call history, raising the window that is already up rather than opening a second.
      * <p>
      * The dialog is modeless and does not block, so it is kept here instead of being forgotten at
@@ -939,6 +932,13 @@ public class McpStatusBarItem
         return delivery == RunningToolCall.Delivery.NOT_ARBITRATED;
     }
 
+    /**
+     * Opens the signal dialog and delivers whatever the user sends. Does nothing unless a tool is
+     * actually executing.
+     *
+     * @param type  the kind of signal
+     * @param title the dialog title
+     */
     private void sendSignal(OperatorSignal.SignalType type, String title)
     {
         McpHttpEndpoint server = Activator.getDefault() != null ? Activator.getDefault().getMcpServer() : null;

--- a/scripts/check-orphan-javadoc.py
+++ b/scripts/check-orphan-javadoc.py
@@ -6,9 +6,8 @@ another javadoc block, a closing brace, or the end of the file. It reads as docu
 whatever follows and documents something else, or nothing at all - and nothing in the build says a
 word, because a comment always compiles.
 
-They arrive the same way every time: a block is inserted above a method that later moves or is
-replaced, and the old block stays behind. One was found by eye in this codebase - a doubled block
-left by an earlier insertion - which is what a census is for.
+They arrive the same way every time: a member moves or is replaced and its block stays behind,
+which leaves the block above some other member's block and the moved member with no header at all.
 
 Reports by default; `--check` fails the build when any orphan stands.
 """
@@ -17,9 +16,9 @@ import pathlib
 import re
 import sys
 
-# The orphans standing when the check was written. It only ever goes down: a fix lowers it,
-# and nothing may raise it.
-BASELINE = 63
+# The orphans allowed to stand. It only ever goes down: a fix lowers it, and nothing may raise it.
+# The 63 the census started with were traced to their members and put back; the floor is now zero.
+BASELINE = 0
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 SOURCES = [


### PR DESCRIPTION
## What changed

A javadoc block documents the declaration under it. 63 blocks in this codebase had another javadoc block under them instead, so they documented nothing - and the member each was written for stood lower in the same file with no header at all. Both halves are fixed at once.

Each block was traced to its member by the parameter names it declares, matched against the parameter list of every declaration in the file that carried no header of its own. 57 matched exactly one and were moved back:

| File | Blocks |
|---|---|
| BmComparisonHelper | 14 |
| DcsWorkshopTool | 9 |
| BmFormHelper, EditMetadataTool | 3 each |
| BmExtensionHelper, BmObjectHelper, MxlWorkshopTool, ProjectProblemsReader | 2 each |
| 20 others | 1 each |

Among the members that now carry their header again: `settingsFor`, `closeEverything`, `awaitMergeEnd`, `mergeWithDeliveryInFront`, `release`, `resolveSourceEObject`, `resolveExtensionProject`, `setScalarProperty`, `executeSinglePending`, `applyMdObjectSynonym`, `opAddTemplate`, `opMergeCells`, `shapeResult`, `sendSignal`, `getCode`, `getStructuredContent`, and the classes `Page`, `Result`, `Capabilities` and `PendingEntry`.

Two headers named fewer parameters than their method takes, each having gained one while it sat detached: `walk` now names `page` and `insideModule`, `describeChange` names `threeWay`.

Six blocks did not move. Five document members that no longer exist - two in `BmSupportRegistryHelper`, three in `MiscOps` - and were removed; one of the two also stated that subordinate entities are not indexed, which the walk has not done for some time. The sixth described `settingsToWorkOn`, which carries its own header; what it said and that header did not - settings are written into a variant rather than into `defaultSettings`, and a schema whose settings live only in `defaultSettings` opens empty in the editor - is now in it.

`scripts/check-orphan-javadoc.py` fails above zero. `docs/test-coverage.md` carries the count the suite reports.

## Verification

`mvn -f mcp/pom.xml clean verify`: BUILD SUCCESS, 2458 tests, 0 failures, 0 errors.

`check-orphan-javadoc.py --check`: 651 java files, 0 orphan blocks. Its own 10 tests pass. The other eight checks are green.

The script that moved the blocks refuses to write unless the line it was given carries the name of the member it is moving a header onto, so a wrong pairing stops the run instead of landing a header on the wrong method. Every move was read back against its member.
