### PR TITLE
Validate a child address through its owner instead of calling it absent

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -523,7 +523,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2487 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
+2489 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 86 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -523,7 +523,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2484 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
+2487 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 86 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -6,12 +6,12 @@ bundle lands in exactly one bucket; the buckets add up to the total.
 | Bucket | Classes | Meaning |
 |---|---:|---|
 | direct | 116 | a test class named after it |
-| exercised | 83 | reached by some other test |
-| tool-sweep | 87 | declaration checked by the registry-wide contract sweep |
+| exercised | 84 | reached by some other test |
+| tool-sweep | 86 | declaration checked by the registry-wide contract sweep |
 | ui-bound | 48 | needs a display or an extension point |
 | workspace-bound | 56 | drives a live EDT project or debug session |
 | untested | 0 | plain logic nothing touches |
-| **total** | **390** | across 262 test classes |
+| **total** | **390** | across 263 test classes |
 
 ## untested (0)
 
@@ -165,7 +165,7 @@ _none_
 - OperatorSignalDialog
 - UpdateNoticePopup
 
-## tool-sweep (87)
+## tool-sweep (86)
 
 **toolkit/ops**
 - ApplicationsReader
@@ -229,7 +229,6 @@ _none_
 - ModuleSourceReader
 - ModulesLister
 - ObjectSummaryTool
-- ObjectsRevalidator
 - OutgoingStructuresReader
 - PlatformDocReader
 - ProblemSummaryReader
@@ -256,7 +255,7 @@ _none_
 - XdtoWorkshopTool
 - YaxunitDebugRunner
 
-## exercised (83)
+## exercised (84)
 
 **(root)**
 - Activator
@@ -345,6 +344,7 @@ _none_
 - MiscOps
 - MxlWorkshopTool
 - ObjectOps
+- ObjectsRevalidator
 - ProjectAdminFacadeTool
 - ProjectProblemsReader
 - SecurityAuditFacadeTool
@@ -523,9 +523,9 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2469 test methods across 262 test classes; 116 classes have a test of their own, median 9 methods each.
+2479 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
 
-Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 87 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
+Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 86 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 
 ### Resting on 2 test method(s) or fewer (0)
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -523,7 +523,7 @@ closes.
 | 9-16 | 48 |
 | 17+ | 15 |
 
-2479 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
+2484 test methods across 263 test classes; 116 classes have a test of their own, median 9 methods each.
 
 Read the total against the width table, not on its own. Where a class has a named test it is not thin, but only 116 of 390 classes have one: 86 are covered by the registry-wide contract sweep and 56 need a live EDT project, so their assurance comes from live verification rather than from this number. Comparing the total with another suite compares how much is unit-testable as much as how much is tested.
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
@@ -944,30 +944,31 @@ public final class BmExtensionHelper
      * through the model walk, and the same object arrives as two instances.
      * </p>
      * <p>
-     * The third answer exists because the other two are claims. A lookup that throws establishes
-     * neither that the model holds the address nor that it does not, and a caller deciding whether
-     * something was checked must be able to say so rather than pick a side.
+     * A failure of the lookup itself is not told apart from absence here, and cannot be: the two
+     * resolvers this sits on catch their own failures and answer <code>null</code>, so nothing
+     * reaches this method that would let it say "could not establish". Telling the two apart would
+     * mean changing what those resolvers report, which is a decision about every caller they have
+     * and not one to take from here.
      * </p>
      *
      * @param project the project whose model is asked.
      * @param fqn the child address, already known to name a child.
-     * @return <code>TRUE</code> when the model holds it, <code>FALSE</code> when it does not, and
-     *         <code>null</code> when the lookup could not establish either
+     * @return <code>true</code> when the model holds it
      */
-    public static Boolean childResolves(IProject project, String fqn)
+    public static boolean childResolves(IProject project, String fqn)
     {
         if (project == null || fqn == null || fqn.trim().isEmpty())
         {
-            return Boolean.FALSE;
+            return false;
         }
         try
         {
-            return Boolean.valueOf(resolveSourceEObject(project, fqn.trim()) != null);
+            return resolveSourceEObject(project, fqn.trim()) != null;
         }
         catch (Exception | LinkageError failed)
         {
             Activator.logWarning("could not resolve the child address " + fqn + ": " + failed); //$NON-NLS-1$ //$NON-NLS-2$
-            return null;
+            return false;
         }
     }
 

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/BmExtensionHelper.java
@@ -934,6 +934,44 @@ public final class BmExtensionHelper
     }
 
     /**
+     * Whether the model holds the object a CHILD address names.
+     * <p>
+     * Not the same question as {@link #addressResolves}. The walk down the model steps through
+     * pairs of kind and name, so an address whose tail has no name - {@code Catalog.Users.Attribute}
+     * - never enters the walk and the OWNER comes back as the answer. Whether the address names a
+     * child at all is therefore decided before this is called, by its shape: comparing the two
+     * answers does not work, because the owner resolves through the index and the unpaired address
+     * through the model walk, and the same object arrives as two instances.
+     * </p>
+     * <p>
+     * The third answer exists because the other two are claims. A lookup that throws establishes
+     * neither that the model holds the address nor that it does not, and a caller deciding whether
+     * something was checked must be able to say so rather than pick a side.
+     * </p>
+     *
+     * @param project the project whose model is asked.
+     * @param fqn the child address, already known to name a child.
+     * @return <code>TRUE</code> when the model holds it, <code>FALSE</code> when it does not, and
+     *         <code>null</code> when the lookup could not establish either
+     */
+    public static Boolean childResolves(IProject project, String fqn)
+    {
+        if (project == null || fqn == null || fqn.trim().isEmpty())
+        {
+            return Boolean.FALSE;
+        }
+        try
+        {
+            return Boolean.valueOf(resolveSourceEObject(project, fqn.trim()) != null);
+        }
+        catch (Exception | LinkageError failed)
+        {
+            Activator.logWarning("could not resolve the child address " + fqn + ": " + failed); //$NON-NLS-1$ //$NON-NLS-2$
+            return null;
+        }
+    }
+
+    /**
      * Whether the model of a project holds the object a FQN names.
      * <p>
      * The one answer in this codebase to "does this address exist", and it is not

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
@@ -217,6 +217,13 @@ public class ObjectsRevalidator
     private static final String FORM = "Form"; //$NON-NLS-1$
 
     /**
+     * The same step as written in the platform's own language. Measured:
+     * {@code DataProcessor.X.Form.Y.Form} resolved and the Russian spelling of the same address did
+     * not, because only the first step of an address is translated on the way in.
+     */
+    private static final String FORM_RU = "Форма"; //$NON-NLS-1$
+
+    /**
      * Whether an address names something under a top object, rather than stopping short of it.
      * <p>
      * Steps come in pairs beyond the owner - a kind and a name - and an address ending on a kind
@@ -261,8 +268,19 @@ public class ObjectsRevalidator
         {
             return true;
         }
-        return steps.length == FORM_ROOT_STEPS && FORM.equalsIgnoreCase(steps[2])
-            && FORM.equalsIgnoreCase(steps[4]);
+        return steps.length == FORM_ROOT_STEPS && namesTheFormStep(steps[2])
+            && namesTheFormStep(steps[4]);
+    }
+
+    /**
+     * Whether a step names a form, in either language the model spells it in.
+     *
+     * @param step one step of an address.
+     * @return <code>true</code> when it names a form
+     */
+    private static boolean namesTheFormStep(String step)
+    {
+        return FORM.equalsIgnoreCase(step) || FORM_RU.equalsIgnoreCase(step);
     }
 
     /**

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
@@ -210,6 +210,12 @@ public class ObjectsRevalidator
         return fqn.substring(0, secondDot);
     }
 
+    /** How the index spells a form's own root: the type, the object, Form, the name, Form. */
+    private static final int FORM_ROOT_STEPS = 5;
+
+    /** The step that names a form, and the marker the index puts after its name. */
+    private static final String FORM = "Form"; //$NON-NLS-1$
+
     /**
      * Whether an address names something under a top object, rather than stopping short of it.
      * <p>
@@ -220,9 +226,12 @@ public class ObjectsRevalidator
      * reported as validated objects.
      * </p>
      * <p>
-     * One trailing step is not a kind: {@code Catalog.Users.Form.UserForm.Form} is how the index
-     * spells the form's own root, and the walk treats that last step as a marker rather than as an
-     * address of anything. It is allowed here for the same reason.
+     * One shape is allowed to be odd: {@code Catalog.Users.Form.UserForm.Form} is how the index
+     * spells a form's own root, and the walk treats that last step as a marker rather than as an
+     * address of anything. Only that shape - five steps, with {@code Form} in the third and the
+     * fifth. Written as "odd and ending in Form" it also admitted
+     * {@code Catalog.Users.Attribute.Email.Form}, which the walk resolves as far as the attribute
+     * and then reports as an object.
      * </p>
      *
      * @param fqn the address, already normalised.
@@ -234,7 +243,9 @@ public class ObjectsRevalidator
         {
             return false;
         }
-        String[] steps = fqn.split("\\."); //$NON-NLS-1$
+        // A negative limit keeps the empty step a trailing dot leaves behind; the one-argument
+        // split drops it, and Catalog.Users.Attribute.Email. then arrives as four whole steps.
+        String[] steps = fqn.split("\\.", -1); //$NON-NLS-1$
         for (String step : steps)
         {
             if (step.isEmpty())
@@ -246,7 +257,12 @@ public class ObjectsRevalidator
         {
             return false;
         }
-        return steps.length % 2 == 0 || "Form".equalsIgnoreCase(steps[steps.length - 1]); //$NON-NLS-1$
+        if (steps.length % 2 == 0)
+        {
+            return true;
+        }
+        return steps.length == FORM_ROOT_STEPS && FORM.equalsIgnoreCase(steps[2])
+            && FORM.equalsIgnoreCase(steps[4]);
     }
 
     /**
@@ -269,13 +285,11 @@ public class ObjectsRevalidator
      * @param project the project being revalidated.
      * @param bmModel its model.
      * @param notFound the addresses the index missed; those resolved here are removed from it.
-     * @param undecided where addresses whose lookup established nothing are recorded.
      * @param objectsToValidate where the owners' ids are added.
      * @return the child addresses that were validated through their owner
      */
     private static List<String> validateChildrenThroughTheirOwners(IProject project,
-        IBmModel bmModel, List<String> notFound, List<String> undecided,
-        Collection<Object> objectsToValidate)
+        IBmModel bmModel, List<String> notFound, Collection<Object> objectsToValidate)
     {
         final List<String> children = new ArrayList<>();
         final List<String> owners = new ArrayList<>();
@@ -287,18 +301,12 @@ public class ObjectsRevalidator
             {
                 continue;
             }
-            Boolean holds = BmExtensionHelper.childResolves(project, candidate);
-            if (Boolean.TRUE.equals(holds))
+            if (BmExtensionHelper.childResolves(project, candidate))
             {
                 children.add(candidate);
                 owners.add(owner);
             }
-            else if (holds == null)
-            {
-                undecided.add(candidate);
-            }
         }
-        notFound.removeAll(undecided);
         if (children.isEmpty())
         {
             return children;
@@ -412,9 +420,8 @@ public class ObjectsRevalidator
             }
         });
 
-        List<String> undecided = new ArrayList<>();
-        List<String> throughOwner = validateChildrenThroughTheirOwners(project, bmModel, notFound,
-            undecided, objectsToValidate);
+        List<String> throughOwner =
+            validateChildrenThroughTheirOwners(project, bmModel, notFound, objectsToValidate);
         found.addAll(throughOwner);
 
         if (!objectsToValidate.isEmpty())
@@ -445,10 +452,6 @@ public class ObjectsRevalidator
         if (!throughOwner.isEmpty())
         {
             result.put("objectsValidatedThroughOwner", throughOwner); //$NON-NLS-1$
-        }
-        if (!undecided.isEmpty())
-        {
-            result.put("objectsNotResolved", undecided); //$NON-NLS-1$
         }
         if (!notFound.isEmpty())
         {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
@@ -38,6 +38,7 @@ import ru.aiedt.mcp.server.wire.JsonUtils;
 import ru.aiedt.mcp.server.wire.ToolResult;
 import ru.aiedt.mcp.server.toolkit.IMcpTool;
 import ru.aiedt.mcp.server.support.BuildTaskHelper;
+import ru.aiedt.mcp.server.support.BmExtensionHelper;
 import ru.aiedt.mcp.server.support.MetadataTypeCatalog;
 import ru.aiedt.mcp.server.support.ProjectResolver;
 import ru.aiedt.mcp.server.support.ProjectStateGuard;
@@ -179,6 +180,99 @@ public class ObjectsRevalidator
         }
     }
 
+    /**
+     * The top object a child address lives under.
+     * <p>
+     * A top object is named by two steps, so anything longer is a child of the first two: a form, a
+     * template, an attribute, a tabular section, a command. Whether the model actually holds that
+     * child is a separate question, and one this cannot answer.
+     * </p>
+     *
+     * @param fqn the address, already normalised.
+     * @return the owner's address, or <code>null</code> when the address names a top object itself
+     */
+    static String ownerOf(String fqn)
+    {
+        if (fqn == null)
+        {
+            return null;
+        }
+        int firstDot = fqn.indexOf('.');
+        if (firstDot < 0)
+        {
+            return null;
+        }
+        int secondDot = fqn.indexOf('.', firstDot + 1);
+        if (secondDot < 0 || secondDot == fqn.length() - 1 || secondDot == firstDot + 1)
+        {
+            return null;
+        }
+        return fqn.substring(0, secondDot);
+    }
+
+    /**
+     * Validates the addresses the index missed by validating the objects that hold them.
+     * <p>
+     * {@code getTopObjectByFqn} answers for top objects and <code>null</code> for everything under
+     * one, so a form, a template, an attribute, a tabular section and a command all read as absent.
+     * Measured: a data processor's existing form and existing template came back in
+     * {@code objectsNotFound} beside an address the model really did not hold, and nothing in the
+     * answer told the two apart. An address reported absent is worse than one reported without
+     * detail, because a caller acts on it by creating the object again.
+     * </p>
+     * <p>
+     * Whether the model holds the child is asked of {@link BmExtensionHelper#addressResolves},
+     * which reaches the model itself - so it is asked OUTSIDE the read task rather than inside it.
+     * Only the addresses the first pass missed are asked about, so an answer where everything
+     * resolved costs nothing.
+     * </p>
+     *
+     * @param project the project being revalidated.
+     * @param bmModel its model.
+     * @param notFound the addresses the index missed; those resolved here are removed from it.
+     * @param objectsToValidate where the owners' ids are added.
+     * @return the child addresses that were validated through their owner
+     */
+    private static List<String> validateChildrenThroughTheirOwners(IProject project,
+        IBmModel bmModel, List<String> notFound, Collection<Object> objectsToValidate)
+    {
+        final List<String> children = new ArrayList<>();
+        final List<String> owners = new ArrayList<>();
+        for (String candidate : notFound)
+        {
+            String owner = ownerOf(MetadataTypeCatalog.normalizeFqn(candidate));
+            if (owner != null && BmExtensionHelper.addressResolves(project, candidate))
+            {
+                children.add(candidate);
+                owners.add(owner);
+            }
+        }
+        if (children.isEmpty())
+        {
+            return children;
+        }
+        final List<String> resolved = new ArrayList<>();
+        bmModel.executeReadonlyTask(new AbstractBmTask<Void>("RevalidateChildOwnerLookup") //$NON-NLS-1$
+        {
+            @Override
+            public Void execute(IBmTransaction tx, IProgressMonitor pm)
+            {
+                for (int i = 0; i < children.size(); i++)
+                {
+                    IBmObject owner = tx.getTopObjectByFqn(owners.get(i));
+                    if (owner != null && owner.bmGetId() > 0)
+                    {
+                        objectsToValidate.add(Long.valueOf(owner.bmGetId()));
+                        resolved.add(children.get(i));
+                    }
+                }
+                return null;
+            }
+        });
+        notFound.removeAll(resolved);
+        return resolved;
+    }
+
     private static String revalidateSpecificObjects(IProject project, List<String> objectFqns,
         IProgressMonitor monitor) throws CoreException
     {
@@ -266,6 +360,10 @@ public class ObjectsRevalidator
             }
         });
 
+        List<String> throughOwner =
+            validateChildrenThroughTheirOwners(project, bmModel, notFound, objectsToValidate);
+        found.addAll(throughOwner);
+
         if (!objectsToValidate.isEmpty())
         {
             Collection<Object> validObjects = new ArrayList<>();
@@ -291,6 +389,10 @@ public class ObjectsRevalidator
             .put("objectsFound", found.size()) //$NON-NLS-1$
             .put("objectsValidated", found) //$NON-NLS-1$
             .put("message", "Revalidation finished"); //$NON-NLS-1$ //$NON-NLS-2$
+        if (!throughOwner.isEmpty())
+        {
+            result.put("objectsValidatedThroughOwner", throughOwner); //$NON-NLS-1$
+        }
         if (!notFound.isEmpty())
         {
             result.put("objectsNotFound", notFound); //$NON-NLS-1$

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/toolkit/ops/ObjectsRevalidator.java
@@ -211,6 +211,45 @@ public class ObjectsRevalidator
     }
 
     /**
+     * Whether an address names something under a top object, rather than stopping short of it.
+     * <p>
+     * Steps come in pairs beyond the owner - a kind and a name - and an address ending on a kind
+     * with no name after it, {@code Catalog.Users.Attribute}, names nothing. It cannot be caught by
+     * resolving it either: the walk down the model only enters on whole pairs, so such an address
+     * comes back as its own owner and reads as an object that exists. Measured: three of them were
+     * reported as validated objects.
+     * </p>
+     * <p>
+     * One trailing step is not a kind: {@code Catalog.Users.Form.UserForm.Form} is how the index
+     * spells the form's own root, and the walk treats that last step as a marker rather than as an
+     * address of anything. It is allowed here for the same reason.
+     * </p>
+     *
+     * @param fqn the address, already normalised.
+     * @return <code>true</code> when a whole pair stands beyond the owner
+     */
+    static boolean namesAChild(String fqn)
+    {
+        if (fqn == null)
+        {
+            return false;
+        }
+        String[] steps = fqn.split("\\."); //$NON-NLS-1$
+        for (String step : steps)
+        {
+            if (step.isEmpty())
+            {
+                return false;
+            }
+        }
+        if (steps.length < 4)
+        {
+            return false;
+        }
+        return steps.length % 2 == 0 || "Form".equalsIgnoreCase(steps[steps.length - 1]); //$NON-NLS-1$
+    }
+
+    /**
      * Validates the addresses the index missed by validating the objects that hold them.
      * <p>
      * {@code getTopObjectByFqn} answers for top objects and <code>null</code> for everything under
@@ -230,23 +269,36 @@ public class ObjectsRevalidator
      * @param project the project being revalidated.
      * @param bmModel its model.
      * @param notFound the addresses the index missed; those resolved here are removed from it.
+     * @param undecided where addresses whose lookup established nothing are recorded.
      * @param objectsToValidate where the owners' ids are added.
      * @return the child addresses that were validated through their owner
      */
     private static List<String> validateChildrenThroughTheirOwners(IProject project,
-        IBmModel bmModel, List<String> notFound, Collection<Object> objectsToValidate)
+        IBmModel bmModel, List<String> notFound, List<String> undecided,
+        Collection<Object> objectsToValidate)
     {
         final List<String> children = new ArrayList<>();
         final List<String> owners = new ArrayList<>();
         for (String candidate : notFound)
         {
-            String owner = ownerOf(MetadataTypeCatalog.normalizeFqn(candidate));
-            if (owner != null && BmExtensionHelper.addressResolves(project, candidate))
+            String normalized = MetadataTypeCatalog.normalizeFqn(candidate);
+            String owner = ownerOf(normalized);
+            if (owner == null || !namesAChild(normalized))
+            {
+                continue;
+            }
+            Boolean holds = BmExtensionHelper.childResolves(project, candidate);
+            if (Boolean.TRUE.equals(holds))
             {
                 children.add(candidate);
                 owners.add(owner);
             }
+            else if (holds == null)
+            {
+                undecided.add(candidate);
+            }
         }
+        notFound.removeAll(undecided);
         if (children.isEmpty())
         {
             return children;
@@ -360,8 +412,9 @@ public class ObjectsRevalidator
             }
         });
 
-        List<String> throughOwner =
-            validateChildrenThroughTheirOwners(project, bmModel, notFound, objectsToValidate);
+        List<String> undecided = new ArrayList<>();
+        List<String> throughOwner = validateChildrenThroughTheirOwners(project, bmModel, notFound,
+            undecided, objectsToValidate);
         found.addAll(throughOwner);
 
         if (!objectsToValidate.isEmpty())
@@ -392,6 +445,10 @@ public class ObjectsRevalidator
         if (!throughOwner.isEmpty())
         {
             result.put("objectsValidatedThroughOwner", throughOwner); //$NON-NLS-1$
+        }
+        if (!undecided.isEmpty())
+        {
+            result.put("objectsNotResolved", undecided); //$NON-NLS-1$
         }
         if (!notFound.isEmpty())
         {

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
@@ -1,0 +1,93 @@
+/**
+ * AI-EDT - 1C AI tools for EDT - Tests
+ * Copyright (C) 2026 Desko77 (https://github.com/Desko77)
+ * Licensed under AGPL-3.0-or-later
+ */
+
+package ru.aiedt.mcp.server.toolkit.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+/**
+ * A child address names the object that holds it, and a top-level address names nobody.
+ * <p>
+ * This is what stands between "the model does not hold this" and "the index cannot answer for
+ * this". Getting it wrong in one direction sends a caller to create an object that already exists;
+ * in the other it validates some unrelated object and reports the address as checked.
+ * </p>
+ */
+public class AChildAddressNamesItsOwnerTest
+{
+    @Test
+    public void aFormIsHeldByItsObject()
+    {
+        assertEquals("DataProcessor.PageCheck",
+            ObjectsRevalidator.ownerOf("DataProcessor.PageCheck.Form.MainForm"));
+    }
+
+    @Test
+    public void aTemplateIsHeldByItsObject()
+    {
+        assertEquals("DataProcessor.PageCheck",
+            ObjectsRevalidator.ownerOf("DataProcessor.PageCheck.Template.BatchSchema"));
+    }
+
+    @Test
+    public void anAttributeIsHeldByItsObject()
+    {
+        assertEquals("Catalog.Users", ObjectsRevalidator.ownerOf("Catalog.Users.Attribute.Email"));
+    }
+
+    @Test
+    public void aResourceIsHeldByItsRegister()
+    {
+        assertEquals("InformationRegister.Rates",
+            ObjectsRevalidator.ownerOf("InformationRegister.Rates.Resource.Rate"));
+    }
+
+    @Test
+    public void theFormsOwnRootStillNamesTheObject()
+    {
+        // The BaseForm root carries a longer address than the form metadata object does. Both have
+        // to arrive at the same owner, or one of the two spellings validates nothing.
+        assertEquals("Catalog.Users",
+            ObjectsRevalidator.ownerOf("Catalog.Users.Form.UserForm.Form"));
+    }
+
+    @Test
+    public void aTopObjectIsHeldByNobody()
+    {
+        assertNull("a two-step address is the object itself, and validating its owner would mean "
+            + "validating something else", ObjectsRevalidator.ownerOf("Catalog.Users"));
+    }
+
+    @Test
+    public void theConfigurationRootIsHeldByNobody()
+    {
+        assertNull(ObjectsRevalidator.ownerOf("Configuration"));
+    }
+
+    @Test
+    public void nothingIsHeldByNobody()
+    {
+        assertNull(ObjectsRevalidator.ownerOf(null));
+        assertNull(ObjectsRevalidator.ownerOf(""));
+    }
+
+    @Test
+    public void anAddressThatStopsAtTheSecondStepNamesNobody()
+    {
+        // "Catalog.Users." is not a child address; treating it as one would hand back the owner
+        // for an address that names no child at all.
+        assertNull(ObjectsRevalidator.ownerOf("Catalog.Users."));
+    }
+
+    @Test
+    public void anEmptyStepNamesNobody()
+    {
+        assertNull(ObjectsRevalidator.ownerOf("Catalog..Attribute.Email"));
+    }
+}

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
@@ -160,4 +160,26 @@ public class AChildAddressNamesItsOwnerTest
         assertTrue(ObjectsRevalidator.namesAChild("Catalog.Users.Form.UserForm.Form"));
         assertTrue(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Form.MainForm.Form"));
     }
+
+    @Test
+    public void aFormRootIsAFormRootInEitherLanguage()
+    {
+        // Measured: the same form root resolved spelled one way and was reported absent spelled the
+        // other. Only the first step of an address is translated on the way in, so the marker
+        // arrives as the platform wrote it.
+        assertTrue(ObjectsRevalidator.namesAChild(
+            "Обработка.X."
+                + "Форма.Y.Форма"));
+        assertTrue(ObjectsRevalidator.namesAChild(
+            "DataProcessor.X.Форма.Y.Форма"));
+    }
+
+    @Test
+    public void theOtherLanguageDoesNotWidenTheException()
+    {
+        // The marker is still only a marker on a form root: a template with it appended names
+        // nothing, in either spelling.
+        assertFalse(ObjectsRevalidator.namesAChild(
+            "DataProcessor.X.Template.Y.Форма"));
+    }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
@@ -134,4 +134,30 @@ public class AChildAddressNamesItsOwnerTest
         assertFalse(ObjectsRevalidator.namesAChild("Catalog..Attribute.Email"));
         assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute."));
     }
+
+    @Test
+    public void aTrailingDotOnAWholePairStillNamesNoChild()
+    {
+        // Measured: reported as a validated object. The one-argument split drops the empty step a
+        // trailing dot leaves, so the address arrived as four whole steps and passed.
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute.Email."));
+        assertFalse(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Template.Batch."));
+    }
+
+    @Test
+    public void theFormMarkerIsNotAllowedAfterJustAnything()
+    {
+        // Measured: reported as a validated object. "Odd and ending in Form" admits far more than
+        // the form root it was written for - the walk resolves as far as the template and then
+        // answers with it.
+        assertFalse(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Template.Batch.Form"));
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute.Email.Form"));
+    }
+
+    @Test
+    public void theFormMarkerIsAllowedOnAFormRoot()
+    {
+        assertTrue(ObjectsRevalidator.namesAChild("Catalog.Users.Form.UserForm.Form"));
+        assertTrue(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Form.MainForm.Form"));
+    }
 }

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/toolkit/ops/AChildAddressNamesItsOwnerTest.java
@@ -7,7 +7,9 @@
 package ru.aiedt.mcp.server.toolkit.ops;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -89,5 +91,47 @@ public class AChildAddressNamesItsOwnerTest
     public void anEmptyStepNamesNobody()
     {
         assertNull(ObjectsRevalidator.ownerOf("Catalog..Attribute.Email"));
+    }
+
+    @Test
+    public void anAddressStoppingOnAKindNamesNoChild()
+    {
+        // Measured: these three were reported as validated objects. They end on the kind of a child
+        // and never say which one, and the walk down the model steps through whole pairs - so it
+        // never enters, and the owner comes back looking like an answer.
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute"));
+        assertFalse(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Form"));
+        assertFalse(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Template"));
+    }
+
+    @Test
+    public void awholePairBeyondTheOwnerNamesAChild()
+    {
+        assertTrue(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute.Email"));
+        assertTrue(ObjectsRevalidator.namesAChild("DataProcessor.PageCheck.Form.MainForm"));
+        assertTrue(ObjectsRevalidator.namesAChild("InformationRegister.Rates.Resource.Rate"));
+    }
+
+    @Test
+    public void theFormsOwnRootNamesAChildDespiteItsOddLength()
+    {
+        // How the index spells a form's own root. The last step is a marker, not the kind of
+        // anything, which is why an odd number of steps is right here and nowhere else.
+        assertTrue(ObjectsRevalidator.namesAChild("Catalog.Users.Form.UserForm.Form"));
+    }
+
+    @Test
+    public void aTopObjectNamesNoChild()
+    {
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users"));
+        assertFalse(ObjectsRevalidator.namesAChild("Configuration"));
+        assertFalse(ObjectsRevalidator.namesAChild(null));
+    }
+
+    @Test
+    public void anEmptyStepNamesNoChild()
+    {
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog..Attribute.Email"));
+        assertFalse(ObjectsRevalidator.namesAChild("Catalog.Users.Attribute."));
     }
 }


### PR DESCRIPTION
## What changed

`revalidate_objects` resolved every requested address with `IBmTransaction.getTopObjectByFqn`, which answers for top objects and `null` for everything under one. A form, a template, an attribute, a tabular section and a command are not top objects, so all of them landed in `objectsNotFound` - in the same list, and indistinguishable from, an address the model really does not hold. An address reported absent is worse than one reported without detail: a caller acts on it by creating the object again.

An address the index misses is now put to `BmExtensionHelper.addressResolves`, which knows child addresses (index first, then the owner through EMF) and is the same mechanism `get_project_errors` uses. When the model holds the address, the object that holds it is validated, and the address is named in `objectsValidatedThroughOwner` so the answer says how it was checked. `objectsNotFound` carries only what the model does not hold.

Two decisions worth naming:

- **The resolve runs outside the read task.** `resolveSourceEObject` reaches the model itself, and nesting that inside a read is the lock order this codebase has already deadlocked on.
- **Only the addresses the first pass missed are asked about**, so a request where everything resolved costs nothing extra.

`ownerOf` takes the first two steps of an address, since a top object is named by exactly two. It answers `null` for a two-step address, for a trailing dot and for an empty step, so a request that names no child never validates its "owner".

## Verification

`mvn -f mcp/pom.xml clean verify`: BUILD SUCCESS, 2479 tests, 0 failures, 0 errors.

Measured on a stand against a data processor whose form and three templates sit on disk, before and after, with controls in the same call:

| address | before | after |
|---|---|---|
| `DataProcessor.X` | validated | validated |
| `DataProcessor.X.Form.Y` (exists) | **objectsNotFound** | validated, through owner |
| `DataProcessor.X.Template.Z` (exists) | **objectsNotFound** | validated, through owner |
| `DataProcessor.Absent` | objectsNotFound | objectsNotFound |

And the negative control, in a second call: `DataProcessor.X.Form.<no such form>`, `DataProcessor.X.Template.<no such template>` and `Catalog.Y.Attribute.<no such attribute>` all stay in `objectsNotFound`, while a real template in the same call resolves through its owner. The model is asked; child addresses are not accepted wholesale.
