### PR TITLE
An empty type record is the extension saying nothing, not a type that would not read

### DIFF
--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ExtensionFitness.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ExtensionFitness.java
@@ -332,6 +332,9 @@ public final class ExtensionFitness
             return found;
         }
 
+        /** What an extension records when it has no type of its own: the element, empty. */
+        static final String NO_OPINION = ""; //$NON-NLS-1$
+
         /**
          * Reads the type a borrowed field was borrowed against.
          * <p>
@@ -345,8 +348,6 @@ public final class ExtensionFitness
          * @param field the borrowed field.
          * @return the type names it was borrowed against, or the ordinary type when it has one
          */
-        /** What an extension records when it has no type of its own: the element, empty. */
-        static final String NO_OPINION = ""; //$NON-NLS-1$
 
         static String borrowedTypeOf(EObject field)
         {

--- a/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ExtensionFitness.java
+++ b/mcp/bundles/ru.aiedt.mcp.server/src/ru/aiedt/mcp/server/support/ExtensionFitness.java
@@ -240,6 +240,14 @@ public final class ExtensionFitness
             }
             String was = MdChildren.borrowedTypeOf(field.getValue());
             String now = MdChildren.typeOf(other);
+            if (MdChildren.NO_OPINION.equals(was))
+            {
+                // The extension holds no type for this attribute, so it takes the delivery's and
+                // the two cannot disagree. Measured: eight of eleven findings on a real extension
+                // were this, reported as "could not be read" - noise that made a healthy extension
+                // look like a broken one.
+                continue;
+            }
             if (was == null || now == null)
             {
                 // Said, not skipped. A type nobody could read is not a type that matches, and a
@@ -337,6 +345,9 @@ public final class ExtensionFitness
          * @param field the borrowed field.
          * @return the type names it was borrowed against, or the ordinary type when it has one
          */
+        /** What an extension records when it has no type of its own: the element, empty. */
+        static final String NO_OPINION = ""; //$NON-NLS-1$
+
         static String borrowedTypeOf(EObject field)
         {
             try
@@ -384,6 +395,13 @@ public final class ExtensionFitness
             {
                 return null;
             }
+            if (((List<?>)entries).isEmpty())
+            {
+                // No entries at all - the extension wrote down that it has no type of its own.
+                // Told apart below from entries whose names would not read: there the extension
+                // HAS an opinion and this could not make it out, which is a different answer.
+                return NO_OPINION;
+            }
             List<String> names = new ArrayList<>();
             for (Object entry : (List<?>)entries)
             {
@@ -396,6 +414,11 @@ public final class ExtensionFitness
             }
             if (names.isEmpty())
             {
+
+
+
+
+
                 return null;
             }
             java.util.Collections.sort(names);

--- a/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ExtensionFitnessTest.java
+++ b/mcp/tests/ru.aiedt.mcp.server.tests/src/ru/aiedt/mcp/server/support/ExtensionFitnessTest.java
@@ -90,13 +90,34 @@ public class ExtensionFitnessTest
     }
 
     @Test
-    public void anEmptyCompositionIsNothingRatherThanAnEmptyName()
+    public void whatCannotBeReadIsNothing()
     {
         // An empty name would compare equal to another empty name, which is how two sides that
-        // were never read come to look like two sides that agree.
-        assertNull(ExtensionFitness.MdChildren.renderBorrowed(new Composition()));
+        // were never read come to look like two sides that agree. Nothing readable here, so
+        // nothing is the answer.
         assertNull(ExtensionFitness.MdChildren.renderBorrowed(null));
         assertNull(ExtensionFitness.MdChildren.renderBorrowed("not a composition at all"));
+    }
+
+    @Test
+    public void aCompositionWithNoEntriesIsAnAnswerOfItsOwn()
+    {
+        // Measured on a real extension: an adopted attribute the extension never retyped carries
+        // <typeExtension/> with nothing in it. That is a record - "I take whatever the delivery
+        // has" - and not a failure to read one. Told apart from unreadable because the caller does
+        // different things with them: this one is skipped, the other is reported.
+        assertEquals(ExtensionFitness.MdChildren.NO_OPINION,
+            ExtensionFitness.MdChildren.renderBorrowed(new Composition()));
+    }
+
+    @Test
+    public void noOpinionIsNotAName()
+    {
+        // The hazard the older wording guarded: a value that renders as a name and compares equal
+        // to another empty one. It has to stay distinguishable from any real type name.
+        assertTrue(ExtensionFitness.MdChildren.NO_OPINION.isEmpty());
+        assertNull(ExtensionFitness.MdChildren.renderBorrowed(
+            new Composition(new Entry(new Named("")))));
     }
 
     /** Stands in for the extension composition block: it answers getTypes with its entries. */


### PR DESCRIPTION
## What changed

Measured on a real BSP extension: `check_release_fitness` answered **11 findings, and 10 of them said the type could not be read on the extension's side**. On disk those attributes carry `<typeExtension/>` - present and empty.

That is a record, not a failure to read one. The extension never retyped the attribute, so it takes whatever the delivery has and the two cannot disagree. Ten of eleven findings on a healthy extension were noise.

`renderBorrowed` answered `null` for both cases, so the caller could not tell them apart. It now distinguishes:

| `typeExtension` | meaning | answer |
|---|---|---|
| no entries | the extension has no type of its own | `NO_OPINION` - skipped, nothing reported |
| entries, names read | it has a type | compared with the delivery |
| entries, names will not read | it has a type nobody could make out | `null` - **still reported** |

The third row is why the branch existed: *"a silent skip here reads in the answer exactly like agreement - which is how a delivery that retyped a borrowed field would pass unnoticed"*. Keying the distinction on whether names came out would have swallowed it; it is keyed on whether the entry list is empty.

## Verification

Full build: `BUILD SUCCESS`, **2502 tests**, 0 failures.

Live on the same extension, after installing: **1 finding** - the real one, an attribute the delivery no longer has. Counted on disk: **12 adopted attributes carry an empty record and none carries a filled one**, so no genuine type comparison existed to be suppressed.

The existing guard `anEmptyCompositionIsNothingRatherThanAnEmptyName` failed on this change, which is what it was for - the contract it pinned did change. It is split rather than relaxed: what cannot be read is still nothing, a composition with no entries is an answer of its own, and a third case holds that the no-opinion value is not a name and cannot be mistaken for a type. That third one caught a flaw in the first cut of this fix.