### PR TITLE
Hold the server to the specification, judged by the specification's own client

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,136 @@
+name: Protocol conformance
+
+# The other censuses read our source. This one asks a client written by the authors of the MCP
+# specification whether the server on the wire behaves as the specification says - and that needs a
+# server actually running inside EDT.
+#
+# Until now the only job that needed a live server (E2E Tests) waited for a self-hosted runner and
+# skipped without one. This job does not: a stock Linux runner materializes Eclipse Platform, then
+# 1C:EDT from the same public p2 the Tycho build already resolves against, then the freshly built
+# plugin, and boots the lot headless under Xvfb.
+#
+# The addresses are READ OUT OF mcp/targets/default/default.target rather than repeated here.
+# Repeating them is how a build and its runtime drift apart: the target moves to a new EDT and this
+# file keeps booting the old one, green all the way.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      # The EDT this targets declares JavaSE-17, and that is what its runtime wants. A newer JDK
+      # here is not a safe default: EDT refuses to start on a runtime above the one it was built
+      # for, and the failure arrives as an exit code with no message.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Maven and p2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.p2
+          key: ${{ runner.os }}-conformance-${{ hashFiles('**/pom.xml', '**/*.target') }}
+          restore-keys: ${{ runner.os }}-conformance-
+
+      - name: Install headless display
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          sudo apt-get install -y libgtk-3-0t64 || sudo apt-get install -y libgtk-3-0 || true
+
+      # Tests are the build job's business; this one needs the p2 repository and nothing else.
+      - name: Build the plugin repository
+        working-directory: mcp
+        env:
+          MAVEN_OPTS: -Xmx2g -XX:+UseParallelGC
+        run: xvfb-run -a mvn clean package --batch-mode --no-transfer-progress -DskipTests
+
+      - name: Read the addresses out of the target platform
+        id: addresses
+        run: python3 scripts/ci/read-target-addresses.py >> "$GITHUB_OUTPUT"
+
+      - name: Materialize Eclipse Platform
+        run: |
+          set -eu
+          curl -fsSL -o /tmp/eclipse.tar.gz "${{ steps.addresses.outputs.eclipse_archive }}"
+          mkdir -p /tmp/edt
+          tar -xzf /tmp/eclipse.tar.gz -C /tmp/edt --strip-components=1
+          test -x /tmp/edt/eclipse
+
+      # One director run for all of it: EDT resolves against the Eclipse release and Orbit
+      # repositories, and splitting the installs makes it resolve against half a closure.
+      - name: Install 1C:EDT and the plugin
+        run: |
+          set -eu
+          /tmp/edt/eclipse -nosplash -consoleLog \
+            -application org.eclipse.equinox.p2.director \
+            -repository "${{ steps.addresses.outputs.edt_p2 }},${{ steps.addresses.outputs.release_p2 }},${{ steps.addresses.outputs.orbit_p2 }},${{ steps.addresses.outputs.orbit_simrel_p2 }},file://$GITHUB_WORKSPACE/mcp/repositories/ru.aiedt.mcp.server.repository/target/repository" \
+            -installIU "${{ steps.addresses.outputs.edt_ius }},ru.aiedt.mcp.server.feature.feature.group" \
+            -destination /tmp/edt -profile SDKProfile
+
+      # The server does not start by itself: mcpServerAutoStart defaults to OFF, so that installing
+      # the plugin never opens a port on a developer's machine without them asking. A fresh
+      # workspace therefore has to be told, or this job would wait for a port that nobody opens.
+      - name: Seed the workspace preferences
+        run: |
+          set -eu
+          SETTINGS=/tmp/ws/.metadata/.plugins/org.eclipse.core.runtime/.settings
+          mkdir -p "$SETTINGS"
+          {
+            echo "eclipse.preferences.version=1"
+            echo "mcpServerAutoStart=true"
+            echo "mcpServerPort=12250"
+          } > "$SETTINGS/ru.aiedt.mcp.server.prefs"
+
+      - name: Boot EDT headless
+        run: |
+          set -eu
+          xvfb-run -a /tmp/edt/eclipse -nosplash -consoleLog -data /tmp/ws \
+            > /tmp/edt-boot.log 2>&1 &
+          echo "EDT_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for the server
+        run: |
+          set -eu
+          for attempt in $(seq 1 90); do
+            if curl -fsS -m 5 http://127.0.0.1:12250/health > /tmp/health.json 2>/dev/null; then
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "The server never answered on :12250. The boot log follows."
+          tail -200 /tmp/edt-boot.log
+          exit 1
+
+      - name: Conformance census
+        run: python3 scripts/check-protocol-conformance.py
+
+      - name: Stop EDT
+        if: always()
+        run: kill "${EDT_PID:-0}" 2>/dev/null || true
+
+      - name: Keep the logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-logs
+          path: |
+            /tmp/edt-boot.log
+            /tmp/health.json
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,18 @@ Supporting scripts:
   (`direct` / `exercised` / `tool-sweep` / `ui-bound` / `workspace-bound` / `untested`), report in
   `docs/test-coverage.md`. `--check` fails while anything sits in `untested`, so a new class
   without a test breaks the census instead of sliding in unnoticed. CI runs it.
+- `scripts/check-protocol-conformance.py` - runs the official MCP conformance suite
+  (`@modelcontextprotocol/conformance`, fetched with npx) against a **running** server, so the
+  question "does this obey the wire specification" is answered by a client written by the people
+  who write the specification rather than by reading our own source. Covers the handshake, version
+  and capability negotiation, the session header, `Accept`/`Content-Type`, `isError`, `ping`, the
+  SSE streams and DNS-rebinding protection.
+  `scripts/conformance-baseline.yml` pins the scenarios that fail on purpose - the ones wanting
+  test fixtures a production catalogue must not ship, and the capabilities this server does not
+  declare. A scenario failing outside that list is a protocol defect; one inside it that starts
+  passing means the entry comes out. Baseline captured 2026-09-12: 9 passed, 23 failed.
+  It refuses when nothing is listening rather than passing, because a gate that goes green having
+  checked nothing is worse than no gate.
 
 ## Architecture
 

--- a/scripts/check-protocol-conformance.py
+++ b/scripts/check-protocol-conformance.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Check this server against the official MCP conformance suite.
+
+The other ten gates read the source. This one asks a real MCP client, written by the people who
+write the specification, whether the server on the wire behaves as the specification says: the
+handshake, version and capability negotiation, the session header, Accept and Content-Type, isError,
+ping, the SSE streams, and the DNS-rebinding protection.
+
+It needs a LIVE server, which is what separates it from the others: there is no way to answer the
+question from the source. When nothing answers, this refuses rather than passing - a gate that goes
+green because it checked nothing is worse than no gate, and this project has paid for that lesson
+more than once.
+
+    python scripts/check-protocol-conformance.py                 # localhost:12250
+    python scripts/check-protocol-conformance.py --url http://127.0.0.1:<port>/mcp
+    python scripts/check-protocol-conformance.py --capture       # print a fresh baseline
+
+Needs npx on PATH. The suite is fetched on demand and not vendored.
+"""
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+SPEC_VERSION = "2025-11-25"
+DEFAULT_URL = "http://127.0.0.1:12250/mcp"
+BASELINE = pathlib.Path(__file__).with_name("conformance-baseline.yml")
+SUMMARY = re.compile(r"^([✓✗])\s+(\S+):\s+(\d+) passed,\s+(\d+) failed")
+TOTAL = re.compile(r"^Total:\s+(\d+) passed,\s+(\d+) failed")
+
+
+def serverAnswers(url):
+    """Whether something is listening, asked before the suite spends a minute finding out."""
+    health = url.rsplit("/mcp", 1)[0] + "/health"
+    try:
+        with urllib.request.urlopen(health, timeout=5) as answer:
+            return json.loads(answer.read().decode("utf-8", "replace"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def run(url, baseline):
+    command = ["npx", "--yes", "@modelcontextprotocol/conformance@latest", "server",
+               "--url", url, "--spec-version", SPEC_VERSION]
+    if baseline:
+        command += ["--expected-failures", str(BASELINE)]
+    finished = subprocess.run(command, capture_output=True, text=True, encoding="utf-8",
+                              errors="replace", shell=(sys.platform == "win32"))
+    return finished.returncode, (finished.stdout or "") + (finished.stderr or "")
+
+
+def scenariosIn(output):
+    passed, failed = [], []
+    for line in output.splitlines():
+        hit = SUMMARY.match(line.strip())
+        if hit:
+            (failed if hit.group(1) == "✗" else passed).append(hit.group(2))
+    return passed, failed
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL, help="the server's /mcp endpoint")
+    parser.add_argument("--capture", action="store_true",
+                        help="print the failing scenarios instead of checking them")
+    options = parser.parse_args()
+
+    if not shutil.which("npx"):
+        print("FAIL: npx is not on PATH, and the suite is fetched with it. "
+              "Nothing was checked.")
+        return 2
+
+    health = serverAnswers(options.url)
+    if health is None:
+        print("FAIL: nothing answered at " + options.url.rsplit("/mcp", 1)[0] + "/health. "
+              "This gate needs a running server; it does not pass by default.")
+        return 2
+    print("server: {} | EDT {} | {}".format(health.get("instance", "?"),
+                                            health.get("edt_version", "?"),
+                                            health.get("phase", "?")))
+
+    code, output = run(options.url, baseline=not options.capture)
+    passed, failed = scenariosIn(output)
+    total = TOTAL.search(output)
+    if total:
+        print("scenarios: {} passed, {} failed".format(total.group(1), total.group(2)))
+
+    if options.capture:
+        print("\n# failing scenarios, for conformance-baseline.yml")
+        print("server:")
+        for name in failed:
+            print("  - " + name)
+        return 0
+
+    if not passed and not failed:
+        # The suite ran and reported nothing at all. Reading that as success would be the same
+        # mistake this gate exists to prevent.
+        print("FAIL: the suite reported no scenarios. Output follows.")
+        print(output[-2000:])
+        return 2
+
+    if code == 0:
+        print("OK: every scenario outside the baseline passed.")
+        return 0
+
+    print("FAIL: the run did not match the baseline. Either a scenario outside it failed - a real "
+          "protocol defect - or one inside it started passing, and the entry should come out.")
+    print(output[-4000:])
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/read-target-addresses.py
+++ b/scripts/ci/read-target-addresses.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Read the p2 addresses the build resolves against out of the target platform.
+
+The conformance job boots the same 1C:EDT the plugin is compiled against. Naming that EDT twice -
+once in the target and once in a workflow - is how a build and its runtime drift apart: the target
+moves to a new release and the job keeps booting the old one, green the whole way. So the job asks
+here instead.
+
+Prints GitHub-Actions outputs on stdout:
+
+    edt_p2, release_p2, orbit_p2, orbit_simrel_p2   the four repositories, comma-free
+    edt_ius                                          the EDT features to install
+    eclipse_archive                                  the runnable platform matching release_p2
+
+Fails loudly when an address is missing rather than printing an empty value: an empty repository
+list makes the p2 director resolve against nothing and report it as a resolution error three
+minutes later, which reads like a broken plugin.
+"""
+import pathlib
+import re
+import sys
+
+TARGET = pathlib.Path(__file__).resolve().parents[2] / "mcp" / "targets" / "default" / "default.target"
+
+# The Eclipse release train a runnable platform archive is published under. The target names the
+# release repository; this maps it to the drop that can actually be unpacked and started.
+PLATFORM_ARCHIVE = {
+    "2023-12": "https://archive.eclipse.org/eclipse/downloads/drops4/R-4.30-202312010110/"
+               "eclipse-platform-4.30-linux-gtk-x86_64.tar.gz",
+    "2024-12": "https://archive.eclipse.org/eclipse/downloads/drops4/R-4.34-202412050720/"
+               "eclipse-platform-4.34-linux-gtk-x86_64.tar.gz",
+    "2025-12": "https://archive.eclipse.org/eclipse/downloads/drops4/R-4.38-202512010920/"
+               "eclipse-platform-4.38-linux-gtk-x86_64.tar.gz",
+}
+
+# The features that make an EDT, as opposed to the platform-support features, of which the target
+# lists one per 1C platform version and none is needed to answer protocol questions.
+WANTED_IUS = ("com._1c.g5.v8.dt.feature.feature.group",
+              "com._1c.g5.v8.dt.thirdparty.feature.group")
+
+
+def locations(text):
+    for block in re.findall(r"<location[^>]*>(.*?)</location>", text, re.S):
+        address = re.search(r'location="([^"]+)"', block)
+        if address:
+            yield address.group(1).rstrip("/") + "/", re.findall(r'<unit id="([^"]+)"', block)
+
+
+def main():
+    # The path is an argument so the refusals below can be shown to refuse, against a target with
+    # a piece taken out, without editing the one the build uses.
+    target = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else TARGET
+    if not target.exists():
+        print("the target platform is not where it was expected: " + str(target), file=sys.stderr)
+        return 2
+    text = target.read_text(encoding="utf-8")
+
+    found = {}
+    ius = set()
+    for address, units in locations(text):
+        if "edt.1c.ru" in address:
+            found["edt_p2"] = address
+            ius.update(unit for unit in units if unit in WANTED_IUS)
+        elif "/releases/" in address:
+            found["release_p2"] = address
+        elif "orbit-aggregation" in address:
+            found["orbit_simrel_p2"] = address
+        elif "/orbit/" in address:
+            found["orbit_p2"] = address
+
+    missing = [name for name in ("edt_p2", "release_p2", "orbit_p2", "orbit_simrel_p2")
+               if name not in found]
+    if missing:
+        print("the target names no " + ", ".join(missing)
+              + " - the job would resolve against an incomplete closure", file=sys.stderr)
+        return 2
+    if not ius:
+        print("the target asks for none of " + ", ".join(WANTED_IUS)
+              + " - there would be no EDT to boot", file=sys.stderr)
+        return 2
+
+    train = re.search(r"/releases/([^/]+)/", found["release_p2"])
+    archive = PLATFORM_ARCHIVE.get(train.group(1) if train else "")
+    if not archive:
+        print("no runnable platform archive is recorded for release train '"
+              + (train.group(1) if train else "?")
+              + "'. Add it to PLATFORM_ARCHIVE, matching the Eclipse base of that train.",
+              file=sys.stderr)
+        return 2
+
+    for name in ("edt_p2", "release_p2", "orbit_p2", "orbit_simrel_p2"):
+        print("{}={}".format(name, found[name]))
+    print("edt_ius=" + ",".join(sorted(ius)))
+    print("eclipse_archive=" + archive)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/conformance-baseline.yml
+++ b/scripts/conformance-baseline.yml
@@ -1,0 +1,58 @@
+# Protocol conformance baseline: the scenarios that are expected to fail.
+#
+# Run through scripts/check-protocol-conformance.py, which calls
+#   npx @modelcontextprotocol/conformance@latest server \
+#     --url <server>/mcp --spec-version 2025-11-25 \
+#     --expected-failures scripts/conformance-baseline.yml
+#
+# Every entry here is a gap this server has on purpose. The gate exists to catch the other kind: a
+# scenario NOT listed here that fails is a protocol defect, and a scenario listed here that starts
+# passing means the list is stale and the entry comes out.
+#
+# Captured 2026-09-12 against a live server (build 0.2.45.202609120609, EDT 2026.2.0.289):
+# 9 passed, 23 failed. Passing, and therefore deliberately absent from this list:
+#   server-initialize, ping, tools-list, server-sse-multiple-streams (2), resources-list,
+#   prompts-list, dns-rebinding-protection (2).
+#
+# Two scenarios the active suite does not run at all: json-schema-2020-12 needs a fixture tool
+# named json_schema_2020_12_tool, and server-sse-polling reports no checks. Neither is listed,
+# because a list of expected failures may only hold scenarios that actually run.
+
+server:
+  # The suite calls tools it expects the server to ship as test fixtures - a `test_simple_text`
+  # that returns a canned body, and so on. This server exposes the tools it exists for and no
+  # fixtures, so every one of these ends in "tool not found". Shipping them would put test doubles
+  # in a production catalogue that agents read.
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-error
+  - tools-call-with-progress
+  - tools-call-sampling
+  - tools-call-elicitation
+
+  # Capabilities this server does not declare in its handshake. It answers with tools and
+  # resources; logging, completion, prompts/get, sampling and elicitation are not offered, so the
+  # scenarios exercising them have nothing to reach. An entry leaves this list when the capability
+  # is implemented, not when the scenario is silenced.
+  - logging-set-level
+  - completion-complete
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+
+  # Resource scenarios that also want fixtures: test://static-text, a binary one, a template, and
+  # a subscription. This server serves aiedt://checks/<check id> - the descriptions of the EDT
+  # validation checks - and says so by name when asked for something else. Subscriptions are not
+  # implemented: nothing here changes under a reader's feet.
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe


### PR DESCRIPTION
## An eleventh gate, and the first that needs a running server

The ten censuses read our own source: they can say that a facade describes the operation it routes
to, or that no production class lacks a test. None of them can say whether the bytes on the wire
match the MCP specification, because that is not a question the source answers.

`scripts/check-protocol-conformance.py` runs the official suite (`@modelcontextprotocol/conformance`,
fetched with npx) against a live server. It covers the handshake, version and capability
negotiation, the session header, `Accept` and `Content-Type`, `isError`, `ping`, the SSE streams and
DNS-rebinding protection.

`scripts/conformance-baseline.yml` pins what fails on purpose: scenarios wanting test fixtures a
production catalogue must not ship, and capabilities this server does not declare. A scenario
failing outside that list is a protocol defect; one inside it that starts passing means the entry
comes out.

Captured against a live server: **9 passed, 23 failed**, every failure in one of those two buckets.
The one suspicious pair was chased down rather than assumed - `resources-list` passes while
`resources-read-text` fails, and it fails because the suite wants a `test://static-text` fixture;
the refusal names what this server does serve.

The gate refuses when nothing is listening and when the suite reports no scenarios at all. Proven by
taking an entry out of the baseline, which turns that scenario's failure into the regression it
would be, and by pointing it at a dead port.

## A stock runner boots EDT

`E2E Tests` has been waiting for a self-hosted runner since it was written, and skips without one,
so nothing has ever held this server to the protocol in CI.

The new workflow needs no runner of ours. It unpacks Eclipse Platform, installs 1C:EDT from the same
public p2 the Tycho build already resolves against, installs the freshly built plugin, and boots it
under Xvfb.

The addresses are read out of `mcp/targets/default/default.target` rather than repeated in the
workflow, because repeating them is how a build and its runtime drift apart - the target moves to a
new EDT and the job keeps booting the old one, green the whole way.
`scripts/ci/read-target-addresses.py` returns the four repositories, the EDT features and the
platform archive matching the release train, and refuses when any is missing rather than printing an
empty value the director would spend three minutes failing to resolve. Its three refusals are proven
against a target with each piece removed.

The workspace preferences are seeded before the boot: `mcpServerAutoStart` is off by default, so
that installing the plugin never opens a port on a developer's machine unasked. A fresh workspace
would otherwise sit there while the job waited for a port nobody opens.

## What is not settled

This workflow has never run. Everything in it that can be checked locally has been - the address
reader against the real target and against broken ones, the gate against a live server and against a
dead port - but whether EDT starts on a stock runner, and how long it takes, only CI can say.
